### PR TITLE
Resolve "no parameters" for constructor

### DIFF
--- a/Vsxmd/Converter.cs
+++ b/Vsxmd/Converter.cs
@@ -48,7 +48,7 @@ namespace Vsxmd
                 .Element("members")
                 .Elements("member")
                 .Select(element => new MemberUnit(element))
-                .Where(member => member.IsSupported)
+                .Where(member => member.Kind != MemberKind.NotSupported)
                 .GroupBy(unit => unit.TypeName)
                 .Select(MemberUnit.ComplementType)
                 .SelectMany(group => group);

--- a/Vsxmd/Converter.cs
+++ b/Vsxmd/Converter.cs
@@ -6,7 +6,6 @@
 
 namespace Vsxmd
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Xml.Linq;
@@ -23,7 +22,7 @@ namespace Vsxmd
         /// Initializes a new instance of the <see cref="Converter"/> class.
         /// </summary>
         /// <param name="xmlPath">The XML document path.</param>
-        public Converter(string xmlPath)
+        internal Converter(string xmlPath)
         {
             this.xmlPath = xmlPath;
         }
@@ -32,7 +31,7 @@ namespace Vsxmd
         /// Convert to Markdown syntax.
         /// </summary>
         /// <returns>The generated Markdown content.</returns>
-        public string ToMarkdown() =>
+        internal string ToMarkdown() =>
             $"{string.Join("\n\n", ToMarkdown(XDocument.Load(this.xmlPath)))}\n";
 
         private static IEnumerable<string> ToMarkdown(XDocument document)

--- a/Vsxmd/Program.cs
+++ b/Vsxmd/Program.cs
@@ -56,6 +56,12 @@ namespace Vsxmd
         private class Test
         {
             /// <summary>
+            /// Initializes a new instance of the <see cref="Test"/> class.
+            /// <para>Test constructor without parameters.</para>
+            /// </summary>
+            internal Test() { }
+
+            /// <summary>
             /// Test generic reference type.
             /// <para>See <see cref="TestGenericParameter{T1, T2}(Expression{Func{T1, T2, string}})"/>.</para>
             /// </summary>

--- a/Vsxmd/Units/AssemblyUnit.cs
+++ b/Vsxmd/Units/AssemblyUnit.cs
@@ -20,7 +20,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The assembly XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>assembly</c>.</exception>
-        public AssemblyUnit(XElement element)
+        internal AssemblyUnit(XElement element)
             : base(element, "assembly")
         {
         }

--- a/Vsxmd/Units/BaseUnit.cs
+++ b/Vsxmd/Units/BaseUnit.cs
@@ -21,7 +21,7 @@ namespace Vsxmd.Units
         /// <param name="element">The XML element.</param>
         /// <param name="elementName">The expected XML element name.</param>
         /// <exception cref="ArgumentException">Throw if XML <paramref name="element"/> name not matches the expected <paramref name="elementName"/>.</exception>
-        public BaseUnit(XElement element, string elementName)
+        internal BaseUnit(XElement element, string elementName)
         {
             if (element.Name != elementName)
             {

--- a/Vsxmd/Units/ExampleUnit.cs
+++ b/Vsxmd/Units/ExampleUnit.cs
@@ -21,7 +21,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The example XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>example</c>.</exception>
-        public ExampleUnit(XElement element)
+        internal ExampleUnit(XElement element)
             : base(element, "example")
         {
         }

--- a/Vsxmd/Units/ExceptionUnit.cs
+++ b/Vsxmd/Units/ExceptionUnit.cs
@@ -21,7 +21,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The exception XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>exception</c>.</exception>
-        public ExceptionUnit(XElement element)
+        internal ExceptionUnit(XElement element)
             : base(element, "exception")
         {
         }

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -19,6 +19,14 @@ namespace Vsxmd.Units
     internal static class Extensions
     {
         /// <summary>
+        /// Convert the <see cref="MemberKind"/> to its lowercase name.
+        /// </summary>
+        /// <param name="memberKind">The member kind.</param>
+        /// <returns>The member kind's lowercase name.</returns>
+        internal static string ToLowerString(this MemberKind memberKind) =>
+            memberKind.ToString().ToLower();
+
+        /// <summary>
         /// Concatenates the <paramref name="value"/>s with the <paramref name="separator"/>.
         /// </summary>
         /// <param name="value">The string values.</param>
@@ -109,10 +117,10 @@ namespace Vsxmd.Units
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The source enumerable.</param>
         /// <param name="index">The index for the n-th last.</param>
-        /// <returns>The target element, default(<typeparamref name="TSource"/>) if not found.</returns>
-        internal static TSource NthLastOrDefault<TSource>(
+        /// <returns>The element at the specified position in the <paramref name="source"/> sequence.</returns>
+        internal static TSource NthLast<TSource>(
             this IEnumerable<TSource> source, int index) =>
-            source.Reverse().ElementAtOrDefault(index);
+            source.Reverse().ElementAt(index - 1);
 
         /// <summary>
         /// Take all element except the last <paramref name="count"/>.

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -6,7 +6,6 @@
 
 namespace Vsxmd.Units
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;

--- a/Vsxmd/Units/MemberKind.cs
+++ b/Vsxmd/Units/MemberKind.cs
@@ -1,0 +1,44 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MemberKind.cs" company="Junle Li">
+//     Copyright (c) Junle Li. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Vsxmd.Units
+{
+    /// <summary>
+    /// The member kind.
+    /// </summary>
+    internal enum MemberKind
+    {
+        /// <summary>
+        /// Not supported member kind.
+        /// </summary>
+        NotSupported,
+
+        /// <summary>
+        /// Type.
+        /// </summary>
+        Type,
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        Constructor,
+
+        /// <summary>
+        /// Constants
+        /// </summary>
+        Constants,
+
+        /// <summary>
+        /// Property.
+        /// </summary>
+        Property,
+
+        /// <summary>
+        /// Method.
+        /// </summary>
+        Method
+    }
+}

--- a/Vsxmd/Units/MemberUnit.cs
+++ b/Vsxmd/Units/MemberUnit.cs
@@ -34,39 +34,6 @@ namespace Vsxmd.Units
             this.type = this.GetAttribute("name").First();
         }
 
-        private enum MemberKind
-        {
-            /// <summary>
-            /// Not supported member kind.
-            /// </summary>
-            NotSupported,
-
-            /// <summary>
-            /// Type.
-            /// </summary>
-            Type,
-
-            /// <summary>
-            /// Constructor.
-            /// </summary>
-            Constructor,
-
-            /// <summary>
-            /// Constants
-            /// </summary>
-            Constants,
-
-            /// <summary>
-            /// Property.
-            /// </summary>
-            Property,
-
-            /// <summary>
-            /// Method.
-            /// </summary>
-            Method
-        }
-
         /// <summary>
         /// Gets the member unit comparer.
         /// </summary>

--- a/Vsxmd/Units/MemberUnit.cs
+++ b/Vsxmd/Units/MemberUnit.cs
@@ -48,10 +48,21 @@ namespace Vsxmd.Units
         public string TypeName => $"{this.NamespaceName}.{this.TypeShortName}";
 
         /// <summary>
-        /// Gets if this member type is supported.
+        /// Gets the member kind, one of <see cref="MemberKind"/>.
         /// </summary>
-        /// <value>If this member type is supported.</value>
-        public bool IsSupported => this.Kind != MemberKind.NotSupported;
+        /// <value>The member kind.</value>
+        public MemberKind Kind =>
+            this.type == 'T'
+            ? MemberKind.Type
+            : this.type == 'F'
+            ? MemberKind.Constants
+            : this.type == 'P'
+            ? MemberKind.Property
+            : this.type == 'M' && this.Name.Contains(".#ctor")
+            ? MemberKind.Constructor
+            : this.type == 'M' && !this.Name.Contains(".#ctor")
+            ? MemberKind.Method
+            : MemberKind.NotSupported;
 
         private string TypeShortName
         {
@@ -87,28 +98,6 @@ namespace Vsxmd.Units
                         return this.NameSegments.TakeAllButLast(2).Join(".");
                     default:
                         return string.Empty;
-                }
-            }
-        }
-
-        private MemberKind Kind
-        {
-            get
-            {
-                switch (this.type)
-                {
-                    case 'T':
-                        return MemberKind.Type;
-                    case 'F':
-                        return MemberKind.Constants;
-                    case 'P':
-                        return MemberKind.Property;
-                    case 'M':
-                        return this.Name.Contains(".#ctor")
-                            ? MemberKind.Constructor
-                            : MemberKind.Method;
-                    default:
-                        return MemberKind.NotSupported;
                 }
             }
         }

--- a/Vsxmd/Units/MemberUnit.cs
+++ b/Vsxmd/Units/MemberUnit.cs
@@ -28,7 +28,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The member XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>member</c>.</exception>
-        public MemberUnit(XElement element)
+        internal MemberUnit(XElement element)
             : base(element, "member")
         {
             this.type = this.GetAttribute("name").First();
@@ -38,20 +38,20 @@ namespace Vsxmd.Units
         /// Gets the member unit comparer.
         /// </summary>
         /// <value>The member unit comparer.</value>
-        public static IComparer<MemberUnit> Comparer { get; }
+        internal static IComparer<MemberUnit> Comparer { get; }
 
         /// <summary>
         /// Gets the type name.
         /// </summary>
         /// <value>The the type name.</value>
         /// <example><c>Vsxmd.Program</c>, <c>Vsxmd.Units.TypeUnit</c>.</example>
-        public string TypeName => $"{this.NamespaceName}.{this.TypeShortName}";
+        internal string TypeName => $"{this.NamespaceName}.{this.TypeShortName}";
 
         /// <summary>
         /// Gets the member kind, one of <see cref="MemberKind"/>.
         /// </summary>
         /// <value>The member kind.</value>
-        public MemberKind Kind =>
+        internal MemberKind Kind =>
             this.type == 'T'
             ? MemberKind.Type
             : this.type == 'F'

--- a/Vsxmd/Units/MemberUnit.cs
+++ b/Vsxmd/Units/MemberUnit.cs
@@ -71,7 +71,7 @@ namespace Vsxmd.Units
               this.Kind == MemberKind.Property ||
               this.Kind == MemberKind.Constructor ||
               this.Kind == MemberKind.Method
-            ? this.NameSegments.NthLastOrDefault(1)
+            ? this.NameSegments.NthLast(2)
             : string.Empty;
 
         private string NamespaceName =>
@@ -84,8 +84,6 @@ namespace Vsxmd.Units
             ? this.NameSegments.TakeAllButLast(2).Join(".")
             : string.Empty;
 
-        private string KindString => this.Kind.ToString().ToLower();
-
         private string Name => this.GetAttribute("name").Substring(2);
 
         private IEnumerable<string> NameSegments => this.Name.ToNameSegments();
@@ -97,7 +95,7 @@ namespace Vsxmd.Units
               this.Kind == MemberKind.Property ||
               this.Kind == MemberKind.Constructor ||
               this.Kind == MemberKind.Method
-            ? $"### {this.NameSegments.Last().Escape()} `{this.KindString}`"
+            ? $"### {this.NameSegments.Last().Escape()} `{this.Kind.ToLowerString()}`"
             : string.Empty;
 
         private IEnumerable<string> InheritDoc =>
@@ -128,7 +126,7 @@ namespace Vsxmd.Units
             ParamUnit.ToMarkdown(
                 this.GetChildren("param"),
                 this.ParamTypes,
-                this.Kind == MemberKind.Constructor || this.Kind == MemberKind.Method);
+                this.Kind);
 
         private IEnumerable<string> ParamTypes =>
             this.Name.GetParamTypes();

--- a/Vsxmd/Units/ParamUnit.cs
+++ b/Vsxmd/Units/ParamUnit.cs
@@ -46,26 +46,28 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="elements">The param XML element list.</param>
         /// <param name="paramTypes">The paramater type names.</param>
-        /// <param name="isParameterKind">Indicates if the member kind have parameters, which is constructor or methods.</param>
+        /// <param name="memberKind">The member kind of the parent element.</param>
         /// <returns>The generated Markdown.</returns>
         /// <remarks>
         /// When the parameter (a.k.a <paramref name="elements"/>) list is empty:
-        /// <para>If parent element kind is constructor or method, it returns a hint about "no parameters".</para>
+        /// <para>If parent element kind is <see cref="MemberKind.Constructor"/> or <see cref="MemberKind.Method"/>, it returns a hint about "no parameters".</para>
         /// <para>If parent element kind is not the value mentioned above, it returns an empty string.</para>
         /// </remarks>
         internal static IEnumerable<string> ToMarkdown(
             IEnumerable<XElement> elements,
             IEnumerable<string> paramTypes,
-            bool isParameterKind)
+            MemberKind memberKind)
         {
             if (!elements.Any())
             {
-                return !isParameterKind
+                return
+                    memberKind != MemberKind.Constructor &&
+                    memberKind != MemberKind.Method
                     ? Enumerable.Empty<string>()
                     : new[]
                     {
                         "##### Parameters",
-                        "This method has no parameters."
+                        $"This {memberKind.ToLowerString()} has no parameters."
                     };
             }
 

--- a/Vsxmd/Units/ParamUnit.cs
+++ b/Vsxmd/Units/ParamUnit.cs
@@ -24,7 +24,7 @@ namespace Vsxmd.Units
         /// <param name="element">The param XML element.</param>
         /// <param name="paramType">The paramter type corresponding to the param XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>param</c>.</exception>
-        public ParamUnit(XElement element, string paramType)
+        internal ParamUnit(XElement element, string paramType)
             : base(element, "param")
         {
             this.paramType = paramType;

--- a/Vsxmd/Units/PermissionUnit.cs
+++ b/Vsxmd/Units/PermissionUnit.cs
@@ -21,7 +21,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The permission XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>permission</c>.</exception>
-        public PermissionUnit(XElement element)
+        internal PermissionUnit(XElement element)
             : base(element, "permission")
         {
         }

--- a/Vsxmd/Units/RemarksUnit.cs
+++ b/Vsxmd/Units/RemarksUnit.cs
@@ -9,7 +9,6 @@ namespace Vsxmd.Units
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text.RegularExpressions;
     using System.Xml.Linq;
 
     /// <summary>
@@ -22,7 +21,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The remarks XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>remarks</c>.</exception>
-        public RemarksUnit(XElement element)
+        internal RemarksUnit(XElement element)
             : base(element, "remarks")
         {
         }

--- a/Vsxmd/Units/ReturnsUnit.cs
+++ b/Vsxmd/Units/ReturnsUnit.cs
@@ -21,7 +21,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The returns XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>returns</c>.</exception>
-        public ReturnsUnit(XElement element)
+        internal ReturnsUnit(XElement element)
             : base(element, "returns")
         {
         }

--- a/Vsxmd/Units/SeealsoUnit.cs
+++ b/Vsxmd/Units/SeealsoUnit.cs
@@ -21,7 +21,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The seealso XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>seealso</c>.</exception>
-        public SeealsoUnit(XElement element)
+        internal SeealsoUnit(XElement element)
             : base(element, "seealso")
         {
         }

--- a/Vsxmd/Units/SummaryUnit.cs
+++ b/Vsxmd/Units/SummaryUnit.cs
@@ -9,7 +9,6 @@ namespace Vsxmd.Units
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text.RegularExpressions;
     using System.Xml.Linq;
 
     /// <summary>
@@ -22,7 +21,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The summary XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>summary</c>.</exception>
-        public SummaryUnit(XElement element)
+        internal SummaryUnit(XElement element)
             : base(element, "summary")
         {
         }

--- a/Vsxmd/Units/TypeparamUnit.cs
+++ b/Vsxmd/Units/TypeparamUnit.cs
@@ -21,7 +21,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="element">The typeparam XML element.</param>
         /// <exception cref="ArgumentException">Throw if XML element name is not <c>typeparam</c>.</exception>
-        public TypeparamUnit(XElement element)
+        internal TypeparamUnit(XElement element)
             : base(element, "typeparam")
         {
         }

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Units\ExceptionUnit.cs" />
     <Compile Include="Units\Extensions.cs" />
     <Compile Include="Units\IUnit.cs" />
+    <Compile Include="Units\MemberKind.cs" />
     <Compile Include="Units\MemberUnit.cs" />
     <Compile Include="Units\ParamUnit.cs" />
     <Compile Include="Units\PermissionUnit.cs" />

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -486,7 +486,11 @@ This method has no parameters.
 
 ##### Namespace
 
-Vsxmd.Units.MemberUnit
+Vsxmd.Units
+
+##### Summary
+
+The member kind.
 
 ### Constants `constants`
 

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -362,7 +362,7 @@ The concatenated string.
 | value | System.Collections.Generic.IEnumerable{System.String} | The string values. |
 | separator | System.String | The separator. |
 
-### NthLastOrDefault\`\`1 `method`
+### NthLast\`\`1 `method`
 
 ##### Summary
 
@@ -370,7 +370,7 @@ Gets the n-th last element from the `source`.
 
 ##### Returns
 
-The target element, default(`TSource`) if not found.
+The element at the specified position in the `source` sequence.
 
 ##### Parameters
 
@@ -407,6 +407,22 @@ The generated enumerable.
 | Name | Description |
 | ---- | ----------- |
 | TSource | The type of the elements of `source`. |
+
+### ToLowerString `method`
+
+##### Summary
+
+Convert the `MemberKind` to its lowercase name.
+
+##### Returns
+
+The member kind's lowercase name.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| memberKind | Vsxmd.Units.MemberKind | The member kind. |
 
 ### ToMarkdownText `method`
 
@@ -675,13 +691,13 @@ The generated Markdown.
 | ---- | ---- | ----------- |
 | elements | System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement} | The param XML element list. |
 | paramTypes | System.Collections.Generic.IEnumerable{System.String} | The paramater type names. |
-| isParameterKind | System.Boolean | Indicates if the member kind have parameters, which is constructor or methods. |
+| memberKind | Vsxmd.Units.MemberKind | The member kind of the parent element. |
 
 ##### Remarks
 
 When the parameter (a.k.a `elements`) list is empty:
 
-If parent element kind is constructor or method, it returns a hint about "no parameters".
+If parent element kind is `Constructor` or `Method`, it returns a hint about "no parameters".
 
 If parent element kind is not the value mentioned above, it returns an empty string.
 
@@ -1000,6 +1016,18 @@ The generated Markdown.
 ##### Namespace
 
 Vsxmd.Program
+
+### #ctor `constructor`
+
+##### Summary
+
+Initializes a new instance of the `Test` class.
+
+Test constructor without parameters.
+
+##### Parameters
+
+This constructor has no parameters.
 
 ### TestBacktickInSummary `method`
 

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -562,11 +562,11 @@ Initializes a new instance of the `MemberUnit` class.
 
 Gets the member unit comparer.
 
-### IsSupported `property`
+### Kind `property`
 
 ##### Summary
 
-Gets if this member type is supported.
+Gets the member kind, one of `MemberKind`.
 
 ### TypeName `property`
 

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -281,6 +281,41 @@
             </summary>
             <returns>The generated Markdown content.</returns>
         </member>
+        <member name="T:Vsxmd.Units.MemberKind">
+            <summary>
+            The member kind.
+            </summary>
+        </member>
+        <member name="F:Vsxmd.Units.MemberKind.NotSupported">
+            <summary>
+            Not supported member kind.
+            </summary>
+        </member>
+        <member name="F:Vsxmd.Units.MemberKind.Type">
+            <summary>
+            Type.
+            </summary>
+        </member>
+        <member name="F:Vsxmd.Units.MemberKind.Constructor">
+            <summary>
+            Constructor.
+            </summary>
+        </member>
+        <member name="F:Vsxmd.Units.MemberKind.Constants">
+            <summary>
+            Constants
+            </summary>
+        </member>
+        <member name="F:Vsxmd.Units.MemberKind.Property">
+            <summary>
+            Property.
+            </summary>
+        </member>
+        <member name="F:Vsxmd.Units.MemberKind.Method">
+            <summary>
+            Method.
+            </summary>
+        </member>
         <member name="T:Vsxmd.Units.MemberUnit">
             <summary>
             Member unit.
@@ -292,36 +327,6 @@
             </summary>
             <param name="element">The member XML element.</param>
             <exception cref="T:System.ArgumentException">Throw if XML element name is not <c>member</c>.</exception>
-        </member>
-        <member name="F:Vsxmd.Units.MemberUnit.MemberKind.NotSupported">
-            <summary>
-            Not supported member kind.
-            </summary>
-        </member>
-        <member name="F:Vsxmd.Units.MemberUnit.MemberKind.Type">
-            <summary>
-            Type.
-            </summary>
-        </member>
-        <member name="F:Vsxmd.Units.MemberUnit.MemberKind.Constructor">
-            <summary>
-            Constructor.
-            </summary>
-        </member>
-        <member name="F:Vsxmd.Units.MemberUnit.MemberKind.Constants">
-            <summary>
-            Constants
-            </summary>
-        </member>
-        <member name="F:Vsxmd.Units.MemberUnit.MemberKind.Property">
-            <summary>
-            Property.
-            </summary>
-        </member>
-        <member name="F:Vsxmd.Units.MemberUnit.MemberKind.Method">
-            <summary>
-            Method.
-            </summary>
         </member>
         <member name="P:Vsxmd.Units.MemberUnit.Comparer">
             <summary>

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -40,6 +40,12 @@
             <param name="args">Program arguments.</param>
             <seealso cref="T:Vsxmd.Program"/>
         </member>
+        <member name="M:Vsxmd.Program.Test.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Vsxmd.Program.Test"/> class.
+            <para>Test constructor without parameters.</para>
+            </summary>
+        </member>
         <member name="M:Vsxmd.Program.Test.TestGenericRefence">
             <summary>
             Test generic reference type.
@@ -195,6 +201,13 @@
             Extensions helper.
             </summary>
         </member>
+        <member name="M:Vsxmd.Units.Extensions.ToLowerString(Vsxmd.Units.MemberKind)">
+            <summary>
+            Convert the <see cref="T:Vsxmd.Units.MemberKind"/> to its lowercase name.
+            </summary>
+            <param name="memberKind">The member kind.</param>
+            <returns>The member kind's lowercase name.</returns>
+        </member>
         <member name="M:Vsxmd.Units.Extensions.Join(System.Collections.Generic.IEnumerable{System.String},System.String)">
             <summary>
             Concatenates the <paramref name="value"/>s with the <paramref name="separator"/>.
@@ -234,14 +247,14 @@
             <param name="name">The member unit name.</param>
             <returns>The method parameter type name list.</returns>
         </member>
-        <member name="M:Vsxmd.Units.Extensions.NthLastOrDefault``1(System.Collections.Generic.IEnumerable{``0},System.Int32)">
+        <member name="M:Vsxmd.Units.Extensions.NthLast``1(System.Collections.Generic.IEnumerable{``0},System.Int32)">
             <summary>
             Gets the n-th last element from the <paramref name="source"/>.
             </summary>
             <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
             <param name="source">The source enumerable.</param>
             <param name="index">The index for the n-th last.</param>
-            <returns>The target element, default(<typeparamref name="TSource"/>) if not found.</returns>
+            <returns>The element at the specified position in the <paramref name="source"/> sequence.</returns>
         </member>
         <member name="M:Vsxmd.Units.Extensions.TakeAllButLast``1(System.Collections.Generic.IEnumerable{``0},System.Int32)">
             <summary>
@@ -377,17 +390,17 @@
         <member name="M:Vsxmd.Units.ParamUnit.ToMarkdown">
             <inheritdoc />
         </member>
-        <member name="M:Vsxmd.Units.ParamUnit.ToMarkdown(System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement},System.Collections.Generic.IEnumerable{System.String},System.Boolean)">
+        <member name="M:Vsxmd.Units.ParamUnit.ToMarkdown(System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement},System.Collections.Generic.IEnumerable{System.String},Vsxmd.Units.MemberKind)">
             <summary>
             Convert the param XML element to Markdown safely.
             </summary>
             <param name="elements">The param XML element list.</param>
             <param name="paramTypes">The paramater type names.</param>
-            <param name="isParameterKind">Indicates if the member kind have parameters, which is constructor or methods.</param>
+            <param name="memberKind">The member kind of the parent element.</param>
             <returns>The generated Markdown.</returns>
             <remarks>
             When the parameter (a.k.a <paramref name="elements"/>) list is empty:
-            <para>If parent element kind is constructor or method, it returns a hint about "no parameters".</para>
+            <para>If parent element kind is <see cref="F:Vsxmd.Units.MemberKind.Constructor"/> or <see cref="F:Vsxmd.Units.MemberKind.Method"/>, it returns a hint about "no parameters".</para>
             <para>If parent element kind is not the value mentioned above, it returns an empty string.</para>
             </remarks>
         </member>

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -341,11 +341,11 @@
             <value>The the type name.</value>
             <example><c>Vsxmd.Program</c>, <c>Vsxmd.Units.TypeUnit</c>.</example>
         </member>
-        <member name="P:Vsxmd.Units.MemberUnit.IsSupported">
+        <member name="P:Vsxmd.Units.MemberUnit.Kind">
             <summary>
-            Gets if this member type is supported.
+            Gets the member kind, one of <see cref="T:Vsxmd.Units.MemberKind"/>.
             </summary>
-            <value>If this member type is supported.</value>
+            <value>The member kind.</value>
         </member>
         <member name="M:Vsxmd.Units.MemberUnit.ToMarkdown">
             <inheritdoc />


### PR DESCRIPTION
- Make back MemberKind as an internal level type.
- Refine MemberUnit and ParamUnit type.
- Avoid public access modifier and use internal instead.