### PR TITLE
Add type reference support.

### DIFF
--- a/Vsxmd/Program.cs
+++ b/Vsxmd/Program.cs
@@ -58,8 +58,11 @@ namespace Vsxmd
             /// <summary>
             /// Initializes a new instance of the <see cref="Test"/> class.
             /// <para>Test constructor without parameters.</para>
+            /// <para>See <see cref="Test()"/></para>
             /// </summary>
-            internal Test() { }
+            internal Test()
+            {
+            }
 
             /// <summary>
             /// Test generic reference type.
@@ -70,6 +73,7 @@ namespace Vsxmd
 
             /// <summary>
             /// Test generic parameter type.
+            /// <para>See <typeparamref name="T1"/> and <typeparamref name="T2"/>.</para>
             /// </summary>
             /// <typeparam name="T1">Generic type 1.</typeparam>
             /// <typeparam name="T2">Generic type 2.</typeparam>
@@ -101,6 +105,24 @@ namespace Vsxmd
             /// </summary>
             /// <returns>Nothing.</returns>
             internal string TestBacktickInSummary() => null;
+        }
+
+        /// <summary>
+        /// Test generic type.
+        /// <para>See <see cref="TestGenericType{T1, T2}"/>.</para>
+        /// </summary>
+        /// <typeparam name="T1">Generic type 1.</typeparam>
+        /// <typeparam name="T2">Generic type 2.</typeparam>
+        private class TestGenericType<T1, T2>
+        {
+            /// <summary>
+            /// Test generic method.
+            /// <para>See <see cref="TestGenericMethod{T3, T4}"/></para>
+            /// </summary>
+            /// <typeparam name="T3">Generic type 3.</typeparam>
+            /// <typeparam name="T4">Generic type 4.</typeparam>
+            /// <returns>Nothing.</returns>
+            internal string TestGenericMethod<T3, T4>() => null;
         }
     }
 }

--- a/Vsxmd/Units/ExceptionUnit.cs
+++ b/Vsxmd/Units/ExceptionUnit.cs
@@ -26,7 +26,7 @@ namespace Vsxmd.Units
         {
         }
 
-        private string Name => this.GetAttribute("cref").Substring(2);
+        private string Name => this.GetAttribute("cref").ToReferenceLink();
 
         private string Description => this.ElementContent;
 
@@ -34,7 +34,7 @@ namespace Vsxmd.Units
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"| {this.Name.Escape()} | {this.Description} |"
+                $"| {this.Name} | {this.Description} |"
             };
 
         /// <summary>

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -62,13 +62,14 @@ namespace Vsxmd.Units
         /// Generate the reference link for the <paramref name="memberName"/>.
         /// </summary>
         /// <param name="memberName">The member name.</param>
+        /// <param name="useShortName">Indicate if use short type name.</param>
         /// <returns>The generated reference link.</returns>
         /// <example>
         /// <para>For <c>T:Vsxmd.Units.MemberUnit</c>, convert it to <c>[MemberUnit](#T-Vsxmd.Units.MemberUnit)</c>.</para>
         /// <para>For <c>T:System.ArgumentException</c>, convert it to <c>[ArgumentException](http://msdn/path/to/System.ArgumentException)</c>.</para>
         /// </example>
-        internal static string ToReferenceLink(this string memberName) =>
-            new MemberName(memberName).ToReferenceLink();
+        internal static string ToReferenceLink(this string memberName, bool useShortName = false) =>
+            new MemberName(memberName).ToReferenceLink(useShortName);
 
         /// <summary>
         /// Wrap the <paramref name="code"/> into Markdown backtick safely.
@@ -208,7 +209,7 @@ namespace Vsxmd.Units
                 switch (child.Name.ToString())
                 {
                     case "see":
-                        return $"{child.Attribute("cref").Value.ToNameSegments().Last().AsCode()}";
+                        return $"{child.Attribute("cref").Value.ToReferenceLink(useShortName: true)}";
                     case "paramref":
                     case "typeparamref":
                         return $"{child.Attribute("name").Value.AsCode()}";

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -8,7 +8,6 @@ namespace Vsxmd.Units
 {
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
     using System.Text.RegularExpressions;
     using System.Xml.Linq;
 
@@ -89,60 +88,6 @@ namespace Vsxmd.Units
             return code.StartsWith("`") || code.EndsWith("`")
                 ? $"{backticks} {code} {backticks}"
                 : $"{backticks}{code}{backticks}";
-        }
-
-        /// <summary>
-        /// Split the member unit <paramref name="name"/> to segments.
-        /// </summary>
-        /// <param name="name">The member unit name.</param>
-        /// <returns>The name segments.</returns>
-        /// <example>Split <c>M:Vsxmd.Converter.#ctor(System.String)</c> to <c>["Vsxmd", "Converter", "#ctor"]</c> string list.</example>
-        internal static IEnumerable<string> ToNameSegments(this string name) =>
-            name.Split('(').First().Split(':').Last().Split('.');
-
-        /// <summary>
-        /// Gets the method parameter type names from the member unit <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name">The member unit name.</param>
-        /// <returns>The method parameter type name list.</returns>
-        /// <example>
-        /// It will prepend the type kind character (<c>T:</c>) to the type string.
-        /// <para>For <c>(System.String,System.Int32)</c>, returns <c>["T:System.String","T:System.Int32"]</c>.</para>
-        /// It also handle generic type.
-        /// <para>For <c>(System.Collections.Generic.IEnumerable{System.String})</c>, returns <c>["T:System.Collections.Generic.IEnumerable{System.String}"]</c>.</para>
-        /// </example>
-        internal static IEnumerable<string> GetParamTypes(this string name)
-        {
-            var paramString = name.Split('(').Last().Trim(')');
-
-            var delta = 0;
-            var list = new List<StringBuilder>()
-            {
-                new StringBuilder("T:")
-            };
-
-            foreach (var character in paramString)
-            {
-                if (character == '{')
-                {
-                    delta++;
-                }
-                else if (character == '}')
-                {
-                    delta--;
-                }
-                else if (character == ',' && delta == 0)
-                {
-                    list.Add(new StringBuilder("T:"));
-                }
-
-                if (character != ',' || delta != 0)
-                {
-                    list.Last().Append(character);
-                }
-            }
-
-            return list.Select(x => x.ToString());
         }
 
         /// <summary>

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -104,6 +104,12 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="name">The member unit name.</param>
         /// <returns>The method parameter type name list.</returns>
+        /// <example>
+        /// It will prepend the type kind character (<c>T:</c>) to the type string.
+        /// <para>For <c>(System.String,System.Int32)</c>, returns <c>["T:System.String","T:System.Int32"]</c>.</para>
+        /// It also handle generic type.
+        /// <para>For <c>(System.Collections.Generic.IEnumerable{System.String})</c>, returns <c>["T:System.Collections.Generic.IEnumerable{System.String}"]</c>.</para>
+        /// </example>
         internal static IEnumerable<string> GetParamTypes(this string name)
         {
             var paramString = name.Split('(').Last().Trim(')');
@@ -111,7 +117,7 @@ namespace Vsxmd.Units
             var delta = 0;
             var list = new List<StringBuilder>()
             {
-                new StringBuilder()
+                new StringBuilder("T:")
             };
 
             foreach (var character in paramString)
@@ -126,7 +132,7 @@ namespace Vsxmd.Units
                 }
                 else if (character == ',' && delta == 0)
                 {
-                    list.Add(new StringBuilder());
+                    list.Add(new StringBuilder("T:"));
                 }
 
                 if (character != ',' || delta != 0)

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -59,6 +59,18 @@ namespace Vsxmd.Units
             $"[#](#{href})";
 
         /// <summary>
+        /// Generate the reference link for the <paramref name="memberName"/>.
+        /// </summary>
+        /// <param name="memberName">The member name.</param>
+        /// <returns>The generated reference link.</returns>
+        /// <example>
+        /// <para>For <c>T:Vsxmd.Units.MemberUnit</c>, convert it to <c>[MemberUnit](#T-Vsxmd.Units.MemberUnit)</c>.</para>
+        /// <para>For <c>T:System.ArgumentException</c>, convert it to <c>[ArgumentException](http://msdn/path/to/System.ArgumentException)</c>.</para>
+        /// </example>
+        internal static string ToReferenceLink(this string memberName) =>
+            new MemberName(memberName).ToReferenceLink();
+
+        /// <summary>
         /// Wrap the <paramref name="code"/> into Markdown backtick safely.
         /// <para>The backtick characters inside the <paramref name="code"/> reverse as it is.</para>
         /// </summary>

--- a/Vsxmd/Units/MemberName.cs
+++ b/Vsxmd/Units/MemberName.cs
@@ -79,15 +79,39 @@ namespace Vsxmd.Units
         private IEnumerable<string> NameSegments =>
             this.LongName.Split('.');
 
+        private string FriendlyName =>
+            this.Kind == MemberKind.Type
+            ? this.TypeShortName
+            : this.Kind == MemberKind.Constants ||
+              this.Kind == MemberKind.Property ||
+              this.Kind == MemberKind.Constructor ||
+              this.Kind == MemberKind.Method
+            ? this.NameSegments.Last()
+            : string.Empty;
+
         /// <summary>
         /// Convert the member name to Markdown reference link.
         /// <para>If then name is under <c>System</c> namespace, the link points to MSDN.</para>
         /// <para>Otherwise, the link points to this page anchor.</para>
         /// </summary>
+        /// <param name="useShortName">Indicate if use short type name.</param>
         /// <returns>The generated Markdown reference link.</returns>
-        internal string ToReferenceLink() =>
+        internal string ToReferenceLink(bool useShortName) =>
             $"{this.Namespace}.".StartsWith("System.")
-            ? $"[{this.LongName.Escape()}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:{this.MsdnName})"
-            : $"[{this.LongName.Escape()}](#{this.Href})";
+            ? $"[{this.GetReferenceName(useShortName).Escape()}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:{this.MsdnName})"
+            : $"[{this.GetReferenceName(useShortName).Escape()}](#{this.Href})";
+
+        private string GetReferenceName(bool useShortName) =>
+            !useShortName
+            ? this.LongName
+            : this.Kind == MemberKind.Type
+            ? this.TypeShortName
+            : this.Kind == MemberKind.Constants ||
+              this.Kind == MemberKind.Property ||
+              this.Kind == MemberKind.Method
+            ? this.FriendlyName
+            : this.Kind == MemberKind.Constructor
+            ? $"{this.TypeShortName}.{this.FriendlyName}"
+            : string.Empty;
     }
 }

--- a/Vsxmd/Units/MemberName.cs
+++ b/Vsxmd/Units/MemberName.cs
@@ -6,13 +6,15 @@
 
 namespace Vsxmd.Units
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
 
     /// <summary>
     /// Member name.
     /// </summary>
-    internal class MemberName
+    internal class MemberName : IComparable<MemberName>
     {
         private readonly string name;
 
@@ -32,7 +34,7 @@ namespace Vsxmd.Units
         /// Gets the member kind, one of <see cref="MemberKind"/>.
         /// </summary>
         /// <value>The member kind.</value>
-        private MemberKind Kind =>
+        internal MemberKind Kind =>
             this.type == 'T'
             ? MemberKind.Type
             : this.type == 'F'
@@ -45,7 +47,45 @@ namespace Vsxmd.Units
             ? MemberKind.Method
             : MemberKind.NotSupported;
 
-        private string Namespace =>
+        /// <summary>
+        /// Gets the link pointing to this member unit.
+        /// </summary>
+        /// <value>The link pointing to this member unit.</value>
+        internal string Link =>
+            $"[{this.FriendlyName.Escape()}](#{this.Href})";
+
+        /// <summary>
+        /// Gets the caption representation for this member name.
+        /// </summary>
+        /// <value>The caption.</value>
+        /// <example>
+        /// <para>For <see cref="MemberKind.Type"/>, show as <c>## Vsxmd.Units.MemberName [#](#here) [^](#contents)</c>.</para>
+        /// <para>For other kinds, show as <c>### Vsxmd.Units.MemberName.Caption [#](#here) [^](#contents)</c>.</para>
+        /// </example>
+        internal string Caption =>
+            this.Kind == MemberKind.Type
+            ? $"{this.Href.ToAnchor()}## {this.FriendlyName.Escape()} {this.Href.ToHereLink()} {TableOfContents.Link}"
+            : this.Kind == MemberKind.Constants ||
+              this.Kind == MemberKind.Property ||
+              this.Kind == MemberKind.Constructor ||
+              this.Kind == MemberKind.Method
+            ? $"{this.Href.ToAnchor()}### {this.FriendlyName.Escape()} `{this.Kind.ToLowerString()}` {this.Href.ToHereLink()} {TableOfContents.Link}"
+            : string.Empty;
+
+        /// <summary>
+        /// Gets the type name.
+        /// </summary>
+        /// <value>The type name.</value>
+        /// <example><c>Vsxmd.Program</c>, <c>Vsxmd.Units.TypeUnit</c>.</example>
+        internal string TypeName =>
+            $"{this.Namespace}.{this.TypeShortName}";
+
+        /// <summary>
+        /// Gets the namespace name.
+        /// </summary>
+        /// <value>The namespace name.</value>
+        /// <example><c>System</c>, <c>Vsxmd</c>, <c>Vsxmd.Units</c>.</example>
+        internal string Namespace =>
             this.Kind == MemberKind.Type
             ? this.NameSegments.TakeAllButLast(1).Join(".")
             : this.Kind == MemberKind.Constants ||
@@ -88,6 +128,58 @@ namespace Vsxmd.Units
               this.Kind == MemberKind.Method
             ? this.NameSegments.Last()
             : string.Empty;
+
+        /// <inheritdoc />
+        public int CompareTo(MemberName other) =>
+            this.TypeShortName != other.TypeShortName
+            ? this.TypeShortName.CompareTo(other.TypeShortName)
+            : this.Kind != other.Kind
+            ? this.Kind.CompareTo(other.Kind)
+            : this.LongName.CompareTo(other.LongName);
+
+        /// <summary>
+        /// Gets the method parameter type names from the member name.
+        /// </summary>
+        /// <returns>The method parameter type name list.</returns>
+        /// <example>
+        /// It will prepend the type kind character (<c>T:</c>) to the type string.
+        /// <para>For <c>(System.String,System.Int32)</c>, returns <c>["T:System.String","T:System.Int32"]</c>.</para>
+        /// It also handle generic type.
+        /// <para>For <c>(System.Collections.Generic.IEnumerable{System.String})</c>, returns <c>["T:System.Collections.Generic.IEnumerable{System.String}"]</c>.</para>
+        /// </example>
+        internal IEnumerable<string> GetParamTypes()
+        {
+            var paramString = this.name.Split('(').Last().Trim(')');
+
+            var delta = 0;
+            var list = new List<StringBuilder>()
+            {
+                new StringBuilder("T:")
+            };
+
+            foreach (var character in paramString)
+            {
+                if (character == '{')
+                {
+                    delta++;
+                }
+                else if (character == '}')
+                {
+                    delta--;
+                }
+                else if (character == ',' && delta == 0)
+                {
+                    list.Add(new StringBuilder("T:"));
+                }
+
+                if (character != ',' || delta != 0)
+                {
+                    list.Last().Append(character);
+                }
+            }
+
+            return list.Select(x => x.ToString());
+        }
 
         /// <summary>
         /// Convert the member name to Markdown reference link.

--- a/Vsxmd/Units/MemberName.cs
+++ b/Vsxmd/Units/MemberName.cs
@@ -1,0 +1,93 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MemberName.cs" company="Junle Li">
+//     Copyright (c) Junle Li. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Vsxmd.Units
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Member name.
+    /// </summary>
+    internal class MemberName
+    {
+        private readonly string name;
+
+        private readonly char type;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemberName"/> class.
+        /// </summary>
+        /// <param name="name">The raw member name. For example, <c>T:Vsxmd.Units.MemberName</c>.</param>
+        internal MemberName(string name)
+        {
+            this.name = name;
+            this.type = name.First();
+        }
+
+        /// <summary>
+        /// Gets the member kind, one of <see cref="MemberKind"/>.
+        /// </summary>
+        /// <value>The member kind.</value>
+        private MemberKind Kind =>
+            this.type == 'T'
+            ? MemberKind.Type
+            : this.type == 'F'
+            ? MemberKind.Constants
+            : this.type == 'P'
+            ? MemberKind.Property
+            : this.type == 'M' && this.name.Contains(".#ctor")
+            ? MemberKind.Constructor
+            : this.type == 'M' && !this.name.Contains(".#ctor")
+            ? MemberKind.Method
+            : MemberKind.NotSupported;
+
+        private string Namespace =>
+            this.Kind == MemberKind.Type
+            ? this.NameSegments.TakeAllButLast(1).Join(".")
+            : this.Kind == MemberKind.Constants ||
+              this.Kind == MemberKind.Property ||
+              this.Kind == MemberKind.Constructor ||
+              this.Kind == MemberKind.Method
+            ? this.NameSegments.TakeAllButLast(2).Join(".")
+            : string.Empty;
+
+        private string TypeShortName =>
+            this.Kind == MemberKind.Type
+            ? this.NameSegments.Last()
+            : this.Kind == MemberKind.Constants ||
+              this.Kind == MemberKind.Property ||
+              this.Kind == MemberKind.Constructor ||
+              this.Kind == MemberKind.Method
+            ? this.NameSegments.NthLast(2)
+            : string.Empty;
+
+        private string Href => this.name
+            .Replace(':', '-')
+            .Replace('(', '-')
+            .Replace(')', '-');
+
+        private string LongName =>
+            this.name.Split('(').First().Split(':').Last();
+
+        private string MsdnName =>
+            this.LongName.Split('{').First();
+
+        private IEnumerable<string> NameSegments =>
+            this.LongName.Split('.');
+
+        /// <summary>
+        /// Convert the member name to Markdown reference link.
+        /// <para>If then name is under <c>System</c> namespace, the link points to MSDN.</para>
+        /// <para>Otherwise, the link points to this page anchor.</para>
+        /// </summary>
+        /// <returns>The generated Markdown reference link.</returns>
+        internal string ToReferenceLink() =>
+            $"{this.Namespace}.".StartsWith("System.")
+            ? $"[{this.LongName.Escape()}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:{this.MsdnName})"
+            : $"[{this.LongName.Escape()}](#{this.Href})";
+    }
+}

--- a/Vsxmd/Units/MemberUnit.cs
+++ b/Vsxmd/Units/MemberUnit.cs
@@ -82,7 +82,7 @@ namespace Vsxmd.Units
         /// <value>The user friendly name for the member.</value>
         private string FriendlyName =>
             this.Kind == MemberKind.Type
-            ? this.TypeShortName
+            ? this.TypeShortName.Escape()
             : this.Kind == MemberKind.Constants ||
               this.Kind == MemberKind.Property ||
               this.Kind == MemberKind.Constructor ||

--- a/Vsxmd/Units/ParamUnit.cs
+++ b/Vsxmd/Units/ParamUnit.cs
@@ -38,7 +38,7 @@ namespace Vsxmd.Units
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"| {this.Name} | {this.paramType.Escape()} | {this.Description} |"
+                $"| {this.Name} | {this.paramType.ToReferenceLink()} | {this.Description} |"
             };
 
         /// <summary>

--- a/Vsxmd/Units/PermissionUnit.cs
+++ b/Vsxmd/Units/PermissionUnit.cs
@@ -26,7 +26,7 @@ namespace Vsxmd.Units
         {
         }
 
-        private string Name => this.GetAttribute("cref").Substring(2);
+        private string Name => this.GetAttribute("cref").ToReferenceLink();
 
         private string Description => this.ElementContent;
 
@@ -34,7 +34,7 @@ namespace Vsxmd.Units
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"| {this.Name.Escape()} | {this.Description} |"
+                $"| {this.Name} | {this.Description} |"
             };
 
         /// <summary>

--- a/Vsxmd/Units/SeealsoUnit.cs
+++ b/Vsxmd/Units/SeealsoUnit.cs
@@ -26,13 +26,11 @@ namespace Vsxmd.Units
         {
         }
 
-        private string Reference => this.GetAttribute("cref").Substring(2);
-
         /// <inheritdoc />
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"- {this.Reference.AsCode()}"
+                $"- {this.GetAttribute("cref").ToReferenceLink()}"
             };
 
         /// <summary>

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Units\Extensions.cs" />
     <Compile Include="Units\IUnit.cs" />
     <Compile Include="Units\MemberKind.cs" />
+    <Compile Include="Units\MemberName.cs" />
     <Compile Include="Units\MemberUnit.cs" />
     <Compile Include="Units\ParamUnit.cs" />
     <Compile Include="Units\PermissionUnit.cs" />

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -35,6 +35,7 @@
   - [ToLowerString](#M-Vsxmd.Units.Extensions.ToLowerString-Vsxmd.Units.MemberKind-)
   - [ToMarkdownText](#M-Vsxmd.Units.Extensions.ToMarkdownText-System.Xml.Linq.XElement-)
   - [ToNameSegments](#M-Vsxmd.Units.Extensions.ToNameSegments-System.String-)
+  - [ToReferenceLink](#M-Vsxmd.Units.Extensions.ToReferenceLink-System.String-)
 - [IUnit](#T-Vsxmd.Units.IUnit)
   - [ToMarkdown](#M-Vsxmd.Units.IUnit.ToMarkdown)
 - [MemberKind](#T-Vsxmd.Units.MemberKind)
@@ -44,6 +45,10 @@
   - [NotSupported](#F-Vsxmd.Units.MemberKind.NotSupported)
   - [Property](#F-Vsxmd.Units.MemberKind.Property)
   - [Type](#F-Vsxmd.Units.MemberKind.Type)
+- [MemberName](#T-Vsxmd.Units.MemberName)
+  - [#ctor](#M-Vsxmd.Units.MemberName.#ctor-System.String-)
+  - [Kind](#P-Vsxmd.Units.MemberName.Kind)
+  - [ToReferenceLink](#M-Vsxmd.Units.MemberName.ToReferenceLink)
 - [MemberUnit](#T-Vsxmd.Units.MemberUnit)
   - [#ctor](#M-Vsxmd.Units.MemberUnit.#ctor-System.Xml.Linq.XElement-)
   - [Comparer](#P-Vsxmd.Units.MemberUnit.Comparer)
@@ -130,7 +135,7 @@ Initializes a new instance of the `AssemblyUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `assembly`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `assembly`. |
 
 <a name='M-Vsxmd.Units.AssemblyUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.AssemblyUnit.ToMarkdown) [^](#contents)
@@ -172,7 +177,7 @@ Initializes a new instance of the `BaseUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML `element` name not matches the expected `elementName`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML `element` name not matches the expected `elementName`. |
 
 <a name='P-Vsxmd.Units.BaseUnit.Element'></a>
 ### Element `property` [#](#P-Vsxmd.Units.BaseUnit.Element) [^](#contents)
@@ -317,7 +322,7 @@ Initializes a new instance of the `ExampleUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `example`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `example`. |
 
 <a name='M-Vsxmd.Units.ExampleUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.ExampleUnit.ToMarkdown) [^](#contents)
@@ -375,7 +380,7 @@ Initializes a new instance of the `ExceptionUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `exception`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `exception`. |
 
 <a name='M-Vsxmd.Units.ExceptionUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.ExceptionUnit.ToMarkdown) [^](#contents)
@@ -642,6 +647,29 @@ The name segments.
 
 Split `M:Vsxmd.Converter.#ctor(System.String)` to `["Vsxmd", "Converter", "#ctor"]` string list.
 
+<a name='M-Vsxmd.Units.Extensions.ToReferenceLink-System.String-'></a>
+### ToReferenceLink `method` [#](#M-Vsxmd.Units.Extensions.ToReferenceLink-System.String-) [^](#contents)
+
+##### Summary
+
+Generate the reference link for the `memberName`.
+
+##### Returns
+
+The generated reference link.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| memberName | System.String | The member name. |
+
+##### Example
+
+For `T:Vsxmd.Units.MemberUnit`, convert it to `[MemberUnit](#T-Vsxmd.Units.MemberUnit)`.
+
+For `T:System.ArgumentException`, convert it to `[ArgumentException](http://msdn/path/to/System.ArgumentException)`.
+
 <a name='T-Vsxmd.Units.IUnit'></a>
 ## IUnit [#](#T-Vsxmd.Units.IUnit) [^](#contents)
 
@@ -721,6 +749,56 @@ Property.
 
 Type.
 
+<a name='T-Vsxmd.Units.MemberName'></a>
+## MemberName [#](#T-Vsxmd.Units.MemberName) [^](#contents)
+
+##### Namespace
+
+Vsxmd.Units
+
+##### Summary
+
+Member name.
+
+<a name='M-Vsxmd.Units.MemberName.#ctor-System.String-'></a>
+### #ctor `constructor` [#](#M-Vsxmd.Units.MemberName.#ctor-System.String-) [^](#contents)
+
+##### Summary
+
+Initializes a new instance of the `MemberName` class.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | System.String | The raw member name. For example, `T:Vsxmd.Units.MemberName`. |
+
+<a name='P-Vsxmd.Units.MemberName.Kind'></a>
+### Kind `property` [#](#P-Vsxmd.Units.MemberName.Kind) [^](#contents)
+
+##### Summary
+
+Gets the member kind, one of `MemberKind`.
+
+<a name='M-Vsxmd.Units.MemberName.ToReferenceLink'></a>
+### ToReferenceLink `method` [#](#M-Vsxmd.Units.MemberName.ToReferenceLink) [^](#contents)
+
+##### Summary
+
+Convert the member name to Markdown reference link.
+
+If then name is under `System` namespace, the link points to MSDN.
+
+Otherwise, the link points to this page anchor.
+
+##### Returns
+
+The generated Markdown reference link.
+
+##### Parameters
+
+This method has no parameters.
+
 <a name='T-Vsxmd.Units.MemberUnit'></a>
 ## MemberUnit [#](#T-Vsxmd.Units.MemberUnit) [^](#contents)
 
@@ -749,7 +827,7 @@ Initializes a new instance of the `MemberUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `member`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `member`. |
 
 <a name='P-Vsxmd.Units.MemberUnit.Comparer'></a>
 ### Comparer `property` [#](#P-Vsxmd.Units.MemberUnit.Comparer) [^](#contents)
@@ -865,7 +943,7 @@ Initializes a new instance of the `ParamUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `param`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `param`. |
 
 <a name='M-Vsxmd.Units.ParamUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.ParamUnit.ToMarkdown) [^](#contents)
@@ -933,7 +1011,7 @@ Initializes a new instance of the `PermissionUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `permission`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `permission`. |
 
 <a name='M-Vsxmd.Units.PermissionUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.PermissionUnit.ToMarkdown) [^](#contents)
@@ -1033,7 +1111,7 @@ Initializes a new instance of the `RemarksUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `remarks`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `remarks`. |
 
 <a name='M-Vsxmd.Units.RemarksUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.RemarksUnit.ToMarkdown) [^](#contents)
@@ -1091,7 +1169,7 @@ Initializes a new instance of the `ReturnsUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `returns`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `returns`. |
 
 <a name='M-Vsxmd.Units.ReturnsUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.ReturnsUnit.ToMarkdown) [^](#contents)
@@ -1149,7 +1227,7 @@ Initializes a new instance of the `SeealsoUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `seealso`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `seealso`. |
 
 <a name='M-Vsxmd.Units.SeealsoUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.SeealsoUnit.ToMarkdown) [^](#contents)
@@ -1207,7 +1285,7 @@ Initializes a new instance of the `SummaryUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `summary`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `summary`. |
 
 <a name='M-Vsxmd.Units.SummaryUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.SummaryUnit.ToMarkdown) [^](#contents)
@@ -1347,7 +1425,7 @@ This method has no parameters.
 
 | Name | Description |
 | ---- | ----------- |
-| Vsxmd.Program.Test.TestGenericParameter\`\`2(System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1,System.String}}) | Just for test. |
+| [Vsxmd.Program.Test.TestGenericParameter\`\`2](#M-Vsxmd.Program.Test.TestGenericParameter``2-System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}}-) | Just for test. |
 
 <a name='M-Vsxmd.Program.Test.TestGenericParameter``2-System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}}-'></a>
 ### TestGenericParameter\`\`2 `method` [#](#M-Vsxmd.Program.Test.TestGenericParameter``2-System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}}-) [^](#contents)
@@ -1485,7 +1563,7 @@ Initializes a new instance of the `TypeparamUnit` class.
 
 | Name | Description |
 | ---- | ----------- |
-| System.ArgumentException | Throw if XML element name is not `typeparam`. |
+| [System.ArgumentException](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.ArgumentException) | Throw if XML element name is not `typeparam`. |
 
 <a name='M-Vsxmd.Units.TypeparamUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.TypeparamUnit.ToMarkdown) [^](#contents)

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -92,7 +92,7 @@
   - [TestGenericParameter\`\`2](#M-Vsxmd.Program.Test.TestGenericParameter``2-System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}}-)
   - [TestGenericPermission](#M-Vsxmd.Program.Test.TestGenericPermission)
   - [TestGenericRefence](#M-Vsxmd.Program.Test.TestGenericRefence)
-- [TestGenericType`2](#T-Vsxmd.Program.TestGenericType`2)
+- [TestGenericType\`2](#T-Vsxmd.Program.TestGenericType`2)
   - [TestGenericMethod\`\`2](#M-Vsxmd.Program.TestGenericType`2.TestGenericMethod``2)
 - [TypeparamUnit](#T-Vsxmd.Units.TypeparamUnit)
   - [#ctor](#M-Vsxmd.Units.TypeparamUnit.#ctor-System.Xml.Linq.XElement-)
@@ -1414,7 +1414,7 @@ Nothing.
 This method has no parameters.
 
 <a name='T-Vsxmd.Program.TestGenericType`2'></a>
-## TestGenericType`2 [#](#T-Vsxmd.Program.TestGenericType`2) [^](#contents)
+## TestGenericType\`2 [#](#T-Vsxmd.Program.TestGenericType`2) [^](#contents)
 
 ##### Namespace
 

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -129,7 +129,7 @@ Initializes a new instance of the `AssemblyUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The assembly XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The assembly XML element. |
 
 ##### Exceptions
 
@@ -170,8 +170,8 @@ Initializes a new instance of the `BaseUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The XML element. |
-| elementName | System.String | The expected XML element name. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The XML element. |
+| elementName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The expected XML element name. |
 
 ##### Exceptions
 
@@ -208,7 +208,7 @@ An `XAttribute` value that has the specified `name`; `null` if there is no attri
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| name | System.Xml.Linq.XName | The `XName` of the `XAttribute` to get. |
+| name | [System.Xml.Linq.XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) | The `XName` of the `XAttribute` to get. |
 
 <a name='M-Vsxmd.Units.BaseUnit.GetChild-System.Xml.Linq.XName-'></a>
 ### GetChild `method` [#](#M-Vsxmd.Units.BaseUnit.GetChild-System.Xml.Linq.XName-) [^](#contents)
@@ -225,7 +225,7 @@ A `XName` that matches the specified `name`, or `null`.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| name | System.Xml.Linq.XName | The `XName` to match. |
+| name | [System.Xml.Linq.XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) | The `XName` to match. |
 
 <a name='M-Vsxmd.Units.BaseUnit.GetChildren-System.Xml.Linq.XName-'></a>
 ### GetChildren `method` [#](#M-Vsxmd.Units.BaseUnit.GetChildren-System.Xml.Linq.XName-) [^](#contents)
@@ -242,7 +242,7 @@ An ``IEnumerable`1`` of `XElement` containing the children that have a matching 
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| name | System.Xml.Linq.XName | The `XName` to match. |
+| name | [System.Xml.Linq.XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) | The `XName` to match. |
 
 <a name='M-Vsxmd.Units.BaseUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.BaseUnit.ToMarkdown) [^](#contents)
@@ -277,7 +277,7 @@ Initializes a new instance of the `Converter` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| xmlPath | System.String | The XML document path. |
+| xmlPath | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The XML document path. |
 
 <a name='M-Vsxmd.Converter.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Converter.ToMarkdown) [^](#contents)
@@ -316,7 +316,7 @@ Initializes a new instance of the `ExampleUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The example XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The example XML element. |
 
 ##### Exceptions
 
@@ -350,7 +350,7 @@ The generated Markdown.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The example XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The example XML element. |
 
 <a name='T-Vsxmd.Units.ExceptionUnit'></a>
 ## ExceptionUnit [#](#T-Vsxmd.Units.ExceptionUnit) [^](#contents)
@@ -374,7 +374,7 @@ Initializes a new instance of the `ExceptionUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The exception XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The exception XML element. |
 
 ##### Exceptions
 
@@ -408,7 +408,7 @@ The generated Markdown.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| elements | System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement} | The exception XML element list. |
+| elements | [System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The exception XML element list. |
 
 <a name='T-Vsxmd.Units.Extensions'></a>
 ## Extensions [#](#T-Vsxmd.Units.Extensions) [^](#contents)
@@ -438,7 +438,7 @@ The Markdwon code span.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| code | System.String | The code span. |
+| code | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The code span. |
 
 ##### Remarks
 
@@ -459,7 +459,7 @@ The escaped content.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| content | System.String | The content. |
+| content | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The content. |
 
 <a name='M-Vsxmd.Units.Extensions.GetParamTypes-System.String-'></a>
 ### GetParamTypes `method` [#](#M-Vsxmd.Units.Extensions.GetParamTypes-System.String-) [^](#contents)
@@ -476,7 +476,17 @@ The method parameter type name list.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| name | System.String | The member unit name. |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The member unit name. |
+
+##### Example
+
+It will prepend the type kind character (`T:`) to the type string.
+
+For `(System.String,System.Int32)`, returns `["T:System.String","T:System.Int32"]`.
+
+It also handle generic type.
+
+For `(System.Collections.Generic.IEnumerable{System.String})`, returns `["T:System.Collections.Generic.IEnumerable{System.String}"]`.
 
 <a name='M-Vsxmd.Units.Extensions.Join-System.Collections.Generic.IEnumerable{System.String},System.String-'></a>
 ### Join `method` [#](#M-Vsxmd.Units.Extensions.Join-System.Collections.Generic.IEnumerable{System.String},System.String-) [^](#contents)
@@ -493,8 +503,8 @@ The concatenated string.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| value | System.Collections.Generic.IEnumerable{System.String} | The string values. |
-| separator | System.String | The separator. |
+| value | [System.Collections.Generic.IEnumerable{System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The string values. |
+| separator | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The separator. |
 
 <a name='M-Vsxmd.Units.Extensions.NthLast``1-System.Collections.Generic.IEnumerable{``0},System.Int32-'></a>
 ### NthLast\`\`1 `method` [#](#M-Vsxmd.Units.Extensions.NthLast``1-System.Collections.Generic.IEnumerable{``0},System.Int32-) [^](#contents)
@@ -511,8 +521,8 @@ The element at the specified position in the `source` sequence.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| source | System.Collections.Generic.IEnumerable{\`\`0} | The source enumerable. |
-| index | System.Int32 | The index for the n-th last. |
+| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The source enumerable. |
+| index | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32) | The index for the n-th last. |
 
 ##### Generic Types
 
@@ -535,8 +545,8 @@ The generated enumerable.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| source | System.Collections.Generic.IEnumerable{\`\`0} | The source enumerable. |
-| count | System.Int32 | The number to except. |
+| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The source enumerable. |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32) | The number to except. |
 
 ##### Generic Types
 
@@ -559,7 +569,7 @@ The anchor for the `href`.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| href | System.String | The href. |
+| href | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The href. |
 
 <a name='M-Vsxmd.Units.Extensions.ToHereLink-System.String-'></a>
 ### ToHereLink `method` [#](#M-Vsxmd.Units.Extensions.ToHereLink-System.String-) [^](#contents)
@@ -576,7 +586,7 @@ The "to here" link for the `href`.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| href | System.String | The href. |
+| href | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The href. |
 
 <a name='M-Vsxmd.Units.Extensions.ToLowerString-Vsxmd.Units.MemberKind-'></a>
 ### ToLowerString `method` [#](#M-Vsxmd.Units.Extensions.ToLowerString-Vsxmd.Units.MemberKind-) [^](#contents)
@@ -593,7 +603,7 @@ The member kind's lowercase name.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| memberKind | Vsxmd.Units.MemberKind | The member kind. |
+| memberKind | [Vsxmd.Units.MemberKind](#T-Vsxmd.Units.MemberKind) | The member kind. |
 
 <a name='M-Vsxmd.Units.Extensions.ToMarkdownText-System.Xml.Linq.XElement-'></a>
 ### ToMarkdownText `method` [#](#M-Vsxmd.Units.Extensions.ToMarkdownText-System.Xml.Linq.XElement-) [^](#contents)
@@ -610,7 +620,7 @@ The generated Markdwon content.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The XML element. |
 
 ##### Example
 
@@ -641,7 +651,7 @@ The name segments.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| name | System.String | The member unit name. |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The member unit name. |
 
 ##### Example
 
@@ -662,7 +672,7 @@ The generated reference link.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| memberName | System.String | The member name. |
+| memberName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The member name. |
 
 ##### Example
 
@@ -771,7 +781,7 @@ Initializes a new instance of the `MemberName` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| name | System.String | The raw member name. For example, `T:Vsxmd.Units.MemberName`. |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The raw member name. For example, `T:Vsxmd.Units.MemberName`. |
 
 <a name='P-Vsxmd.Units.MemberName.Kind'></a>
 ### Kind `property` [#](#P-Vsxmd.Units.MemberName.Kind) [^](#contents)
@@ -821,7 +831,7 @@ Initializes a new instance of the `MemberUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The member XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The member XML element. |
 
 ##### Exceptions
 
@@ -883,7 +893,7 @@ The complemented member unit group.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| group | System.Collections.Generic.IEnumerable{Vsxmd.Units.MemberUnit} | The member unit group. |
+| group | [System.Collections.Generic.IEnumerable{Vsxmd.Units.MemberUnit}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The member unit group. |
 
 <a name='M-Vsxmd.Units.MemberUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.MemberUnit.ToMarkdown) [^](#contents)
@@ -936,8 +946,8 @@ Initializes a new instance of the `ParamUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The param XML element. |
-| paramType | System.String | The paramter type corresponding to the param XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The param XML element. |
+| paramType | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The paramter type corresponding to the param XML element. |
 
 ##### Exceptions
 
@@ -971,9 +981,9 @@ The generated Markdown.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| elements | System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement} | The param XML element list. |
-| paramTypes | System.Collections.Generic.IEnumerable{System.String} | The paramater type names. |
-| memberKind | Vsxmd.Units.MemberKind | The member kind of the parent element. |
+| elements | [System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The param XML element list. |
+| paramTypes | [System.Collections.Generic.IEnumerable{System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The paramater type names. |
+| memberKind | [Vsxmd.Units.MemberKind](#T-Vsxmd.Units.MemberKind) | The member kind of the parent element. |
 
 ##### Remarks
 
@@ -1005,7 +1015,7 @@ Initializes a new instance of the `PermissionUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The permission XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The permission XML element. |
 
 ##### Exceptions
 
@@ -1039,7 +1049,7 @@ The generated Markdown.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| elements | System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement} | The permission XML element list. |
+| elements | [System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The permission XML element list. |
 
 <a name='T-Vsxmd.Program'></a>
 ## Program [#](#T-Vsxmd.Program) [^](#contents)
@@ -1056,7 +1066,7 @@ Program entry.
 
 | Name | Description |
 | ---- | ----------- |
-| System.Security.PermissionSet | Vsxmd provides no program APIs. |
+| [System.Security.PermissionSet](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.PermissionSet) | Vsxmd provides no program APIs. |
 
 ##### Remarks
 
@@ -1077,11 +1087,11 @@ Program main function entry.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| args | System.String[] | Program arguments. |
+| args | [System.String[]](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String[]) | Program arguments. |
 
 ##### See Also
 
-- `Vsxmd.Program`
+- [Vsxmd.Program](#T-Vsxmd.Program)
 
 <a name='T-Vsxmd.Units.RemarksUnit'></a>
 ## RemarksUnit [#](#T-Vsxmd.Units.RemarksUnit) [^](#contents)
@@ -1105,7 +1115,7 @@ Initializes a new instance of the `RemarksUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The remarks XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The remarks XML element. |
 
 ##### Exceptions
 
@@ -1139,7 +1149,7 @@ The generated Markdown.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The remarks XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The remarks XML element. |
 
 <a name='T-Vsxmd.Units.ReturnsUnit'></a>
 ## ReturnsUnit [#](#T-Vsxmd.Units.ReturnsUnit) [^](#contents)
@@ -1163,7 +1173,7 @@ Initializes a new instance of the `ReturnsUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The returns XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The returns XML element. |
 
 ##### Exceptions
 
@@ -1197,7 +1207,7 @@ The generated Markdown.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The returns XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The returns XML element. |
 
 <a name='T-Vsxmd.Units.SeealsoUnit'></a>
 ## SeealsoUnit [#](#T-Vsxmd.Units.SeealsoUnit) [^](#contents)
@@ -1221,7 +1231,7 @@ Initializes a new instance of the `SeealsoUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The seealso XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The seealso XML element. |
 
 ##### Exceptions
 
@@ -1255,7 +1265,7 @@ The generated Markdown.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| elements | System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement} | The seealso XML element list. |
+| elements | [System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The seealso XML element list. |
 
 <a name='T-Vsxmd.Units.SummaryUnit'></a>
 ## SummaryUnit [#](#T-Vsxmd.Units.SummaryUnit) [^](#contents)
@@ -1279,7 +1289,7 @@ Initializes a new instance of the `SummaryUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The summary XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The summary XML element. |
 
 ##### Exceptions
 
@@ -1313,7 +1323,7 @@ The generated Markdown.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The summary XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The summary XML element. |
 
 <a name='T-Vsxmd.TableOfContents'></a>
 ## TableOfContents [#](#T-Vsxmd.TableOfContents) [^](#contents)
@@ -1339,7 +1349,7 @@ It convert the table of contents from the `memberUnits`.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| memberUnits | System.Linq.IOrderedEnumerable{Vsxmd.Units.MemberUnit} | The member unit list. |
+| memberUnits | [System.Linq.IOrderedEnumerable{Vsxmd.Units.MemberUnit}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IOrderedEnumerable) | The member unit list. |
 
 <a name='P-Vsxmd.TableOfContents.Link'></a>
 ### Link `property` [#](#P-Vsxmd.TableOfContents.Link) [^](#contents)
@@ -1444,7 +1454,7 @@ Nothing.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| expression | System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1,System.String}} | The linq expression. |
+| expression | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1,System.String}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression) | The linq expression. |
 
 ##### Generic Types
 
@@ -1472,7 +1482,7 @@ This method has no parameters.
 
 | Name | Description |
 | ---- | ----------- |
-| Vsxmd.Program.Test.TestGenericParameter\`\`2(System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1,System.String}}) | Just for test. |
+| [Vsxmd.Program.Test.TestGenericParameter\`\`2](#M-Vsxmd.Program.Test.TestGenericParameter``2-System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}}-) | Just for test. |
 
 <a name='M-Vsxmd.Program.Test.TestGenericRefence'></a>
 ### TestGenericRefence `method` [#](#M-Vsxmd.Program.Test.TestGenericRefence) [^](#contents)
@@ -1557,7 +1567,7 @@ Initializes a new instance of the `TypeparamUnit` class.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| element | System.Xml.Linq.XElement | The typeparam XML element. |
+| element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) | The typeparam XML element. |
 
 ##### Exceptions
 
@@ -1591,4 +1601,4 @@ The generated Markdown.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| elements | System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement} | The param XML element list. |
+| elements | [System.Collections.Generic.IEnumerable{System.Xml.Linq.XElement}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable) | The param XML element list. |

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -92,6 +92,8 @@
   - [TestGenericParameter\`\`2](#M-Vsxmd.Program.Test.TestGenericParameter``2-System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}}-)
   - [TestGenericPermission](#M-Vsxmd.Program.Test.TestGenericPermission)
   - [TestGenericRefence](#M-Vsxmd.Program.Test.TestGenericRefence)
+- [TestGenericType`2](#T-Vsxmd.Program.TestGenericType`2)
+  - [TestGenericMethod\`\`2](#M-Vsxmd.Program.TestGenericType`2.TestGenericMethod``2)
 - [TypeparamUnit](#T-Vsxmd.Units.TypeparamUnit)
   - [#ctor](#M-Vsxmd.Units.TypeparamUnit.#ctor-System.Xml.Linq.XElement-)
   - [ToMarkdown](#M-Vsxmd.Units.TypeparamUnit.ToMarkdown)
@@ -1299,6 +1301,8 @@ Initializes a new instance of the `Test` class.
 
 Test constructor without parameters.
 
+See `#ctor`
+
 ##### Parameters
 
 This constructor has no parameters.
@@ -1351,6 +1355,8 @@ This method has no parameters.
 ##### Summary
 
 Test generic parameter type.
+
+See `T1` and `T2`.
 
 ##### Returns
 
@@ -1406,6 +1412,50 @@ Nothing.
 ##### Parameters
 
 This method has no parameters.
+
+<a name='T-Vsxmd.Program.TestGenericType`2'></a>
+## TestGenericType`2 [#](#T-Vsxmd.Program.TestGenericType`2) [^](#contents)
+
+##### Namespace
+
+Vsxmd.Program
+
+##### Summary
+
+Test generic type.
+
+See ``TestGenericType`2``.
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T1 | Generic type 1. |
+| T2 | Generic type 2. |
+
+<a name='M-Vsxmd.Program.TestGenericType`2.TestGenericMethod``2'></a>
+### TestGenericMethod\`\`2 `method` [#](#M-Vsxmd.Program.TestGenericType`2.TestGenericMethod``2) [^](#contents)
+
+##### Summary
+
+Test generic method.
+
+See ```TestGenericMethod``2```
+
+##### Returns
+
+Nothing.
+
+##### Parameters
+
+This method has no parameters.
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T3 | Generic type 3. |
+| T4 | Generic type 4. |
 
 <a name='T-Vsxmd.Units.TypeparamUnit'></a>
 ## TypeparamUnit [#](#T-Vsxmd.Units.TypeparamUnit) [^](#contents)

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -35,7 +35,7 @@
   - [ToLowerString](#M-Vsxmd.Units.Extensions.ToLowerString-Vsxmd.Units.MemberKind-)
   - [ToMarkdownText](#M-Vsxmd.Units.Extensions.ToMarkdownText-System.Xml.Linq.XElement-)
   - [ToNameSegments](#M-Vsxmd.Units.Extensions.ToNameSegments-System.String-)
-  - [ToReferenceLink](#M-Vsxmd.Units.Extensions.ToReferenceLink-System.String-)
+  - [ToReferenceLink](#M-Vsxmd.Units.Extensions.ToReferenceLink-System.String,System.Boolean-)
 - [IUnit](#T-Vsxmd.Units.IUnit)
   - [ToMarkdown](#M-Vsxmd.Units.IUnit.ToMarkdown)
 - [MemberKind](#T-Vsxmd.Units.MemberKind)
@@ -48,7 +48,7 @@
 - [MemberName](#T-Vsxmd.Units.MemberName)
   - [#ctor](#M-Vsxmd.Units.MemberName.#ctor-System.String-)
   - [Kind](#P-Vsxmd.Units.MemberName.Kind)
-  - [ToReferenceLink](#M-Vsxmd.Units.MemberName.ToReferenceLink)
+  - [ToReferenceLink](#M-Vsxmd.Units.MemberName.ToReferenceLink-System.Boolean-)
 - [MemberUnit](#T-Vsxmd.Units.MemberUnit)
   - [#ctor](#M-Vsxmd.Units.MemberUnit.#ctor-System.Xml.Linq.XElement-)
   - [Comparer](#P-Vsxmd.Units.MemberUnit.Comparer)
@@ -123,7 +123,7 @@ Assembly unit.
 
 ##### Summary
 
-Initializes a new instance of the `AssemblyUnit` class.
+Initializes a new instance of the [AssemblyUnit](#T-Vsxmd.Units.AssemblyUnit) class.
 
 ##### Parameters
 
@@ -164,7 +164,7 @@ The base unit.
 
 ##### Summary
 
-Initializes a new instance of the `BaseUnit` class.
+Initializes a new instance of the [BaseUnit](#T-Vsxmd.Units.BaseUnit) class.
 
 ##### Parameters
 
@@ -198,17 +198,17 @@ Gets the Markdown content representing the element.
 
 ##### Summary
 
-Returns the `XAttribute` value of this `XElement` that has the specified `name`.
+Returns the [XAttribute](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XAttribute) value of this [XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) that has the specified `name`.
 
 ##### Returns
 
-An `XAttribute` value that has the specified `name`; `null` if there is no attribute with the specified `name`.
+An [XAttribute](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XAttribute) value that has the specified `name`; `null` if there is no attribute with the specified `name`.
 
 ##### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| name | [System.Xml.Linq.XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) | The `XName` of the `XAttribute` to get. |
+| name | [System.Xml.Linq.XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) | The [XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) of the [XAttribute](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XAttribute) to get. |
 
 <a name='M-Vsxmd.Units.BaseUnit.GetChild-System.Xml.Linq.XName-'></a>
 ### GetChild `method` [#](#M-Vsxmd.Units.BaseUnit.GetChild-System.Xml.Linq.XName-) [^](#contents)
@@ -219,30 +219,30 @@ Gets the first (in document order) child element with the specified `name`.
 
 ##### Returns
 
-A `XName` that matches the specified `name`, or `null`.
+A [XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) that matches the specified `name`, or `null`.
 
 ##### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| name | [System.Xml.Linq.XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) | The `XName` to match. |
+| name | [System.Xml.Linq.XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) | The [XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) to match. |
 
 <a name='M-Vsxmd.Units.BaseUnit.GetChildren-System.Xml.Linq.XName-'></a>
 ### GetChildren `method` [#](#M-Vsxmd.Units.BaseUnit.GetChildren-System.Xml.Linq.XName-) [^](#contents)
 
 ##### Summary
 
-Returns a collection of the child elements of this element or document, in document order. Only elements that have a matching `XName` are included in the collection.
+Returns a collection of the child elements of this element or document, in document order. Only elements that have a matching [XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) are included in the collection.
 
 ##### Returns
 
-An ``IEnumerable`1`` of `XElement` containing the children that have a matching `XName`, in document order.
+An [IEnumerable\`1](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable`1) of [XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement) containing the children that have a matching [XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName), in document order.
 
 ##### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| name | [System.Xml.Linq.XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) | The `XName` to match. |
+| name | [System.Xml.Linq.XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) | The [XName](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XName) to match. |
 
 <a name='M-Vsxmd.Units.BaseUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.BaseUnit.ToMarkdown) [^](#contents)
@@ -271,7 +271,7 @@ Convert from XML docuement to Markdown syntax.
 
 ##### Summary
 
-Initializes a new instance of the `Converter` class.
+Initializes a new instance of the [Converter](#T-Vsxmd.Converter) class.
 
 ##### Parameters
 
@@ -310,7 +310,7 @@ Example unit.
 
 ##### Summary
 
-Initializes a new instance of the `ExampleUnit` class.
+Initializes a new instance of the [ExampleUnit](#T-Vsxmd.Units.ExampleUnit) class.
 
 ##### Parameters
 
@@ -368,7 +368,7 @@ Exception unit.
 
 ##### Summary
 
-Initializes a new instance of the `ExceptionUnit` class.
+Initializes a new instance of the [ExceptionUnit](#T-Vsxmd.Units.ExceptionUnit) class.
 
 ##### Parameters
 
@@ -593,7 +593,7 @@ The "to here" link for the `href`.
 
 ##### Summary
 
-Convert the `MemberKind` to its lowercase name.
+Convert the [MemberKind](#T-Vsxmd.Units.MemberKind) to its lowercase name.
 
 ##### Returns
 
@@ -657,8 +657,8 @@ The name segments.
 
 Split `M:Vsxmd.Converter.#ctor(System.String)` to `["Vsxmd", "Converter", "#ctor"]` string list.
 
-<a name='M-Vsxmd.Units.Extensions.ToReferenceLink-System.String-'></a>
-### ToReferenceLink `method` [#](#M-Vsxmd.Units.Extensions.ToReferenceLink-System.String-) [^](#contents)
+<a name='M-Vsxmd.Units.Extensions.ToReferenceLink-System.String,System.Boolean-'></a>
+### ToReferenceLink `method` [#](#M-Vsxmd.Units.Extensions.ToReferenceLink-System.String,System.Boolean-) [^](#contents)
 
 ##### Summary
 
@@ -673,6 +673,7 @@ The generated reference link.
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | memberName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The member name. |
+| useShortName | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean) | Indicate if use short type name. |
 
 ##### Example
 
@@ -689,7 +690,7 @@ Vsxmd.Units
 
 ##### Summary
 
-`IUnit` is wrapper to handle XML elements.
+[IUnit](#T-Vsxmd.Units.IUnit) is wrapper to handle XML elements.
 
 <a name='M-Vsxmd.Units.IUnit.ToMarkdown'></a>
 ### ToMarkdown `method` [#](#M-Vsxmd.Units.IUnit.ToMarkdown) [^](#contents)
@@ -775,7 +776,7 @@ Member name.
 
 ##### Summary
 
-Initializes a new instance of the `MemberName` class.
+Initializes a new instance of the [MemberName](#T-Vsxmd.Units.MemberName) class.
 
 ##### Parameters
 
@@ -788,10 +789,10 @@ Initializes a new instance of the `MemberName` class.
 
 ##### Summary
 
-Gets the member kind, one of `MemberKind`.
+Gets the member kind, one of [MemberKind](#T-Vsxmd.Units.MemberKind).
 
-<a name='M-Vsxmd.Units.MemberName.ToReferenceLink'></a>
-### ToReferenceLink `method` [#](#M-Vsxmd.Units.MemberName.ToReferenceLink) [^](#contents)
+<a name='M-Vsxmd.Units.MemberName.ToReferenceLink-System.Boolean-'></a>
+### ToReferenceLink `method` [#](#M-Vsxmd.Units.MemberName.ToReferenceLink-System.Boolean-) [^](#contents)
 
 ##### Summary
 
@@ -807,7 +808,9 @@ The generated Markdown reference link.
 
 ##### Parameters
 
-This method has no parameters.
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| useShortName | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean) | Indicate if use short type name. |
 
 <a name='T-Vsxmd.Units.MemberUnit'></a>
 ## MemberUnit [#](#T-Vsxmd.Units.MemberUnit) [^](#contents)
@@ -825,7 +828,7 @@ Member unit.
 
 ##### Summary
 
-Initializes a new instance of the `MemberUnit` class.
+Initializes a new instance of the [MemberUnit](#T-Vsxmd.Units.MemberUnit) class.
 
 ##### Parameters
 
@@ -858,7 +861,7 @@ Gets the user friendly name for the member. This name will be shown as caption.
 
 ##### Summary
 
-Gets the member kind, one of `MemberKind`.
+Gets the member kind, one of [MemberKind](#T-Vsxmd.Units.MemberKind).
 
 <a name='P-Vsxmd.Units.MemberUnit.Link'></a>
 ### Link `property` [#](#P-Vsxmd.Units.MemberUnit.Link) [^](#contents)
@@ -883,7 +886,7 @@ Gets the type name.
 
 ##### Summary
 
-Complement a type unit if the member unit `group` does not have one. One member unit group has the same `TypeName`.
+Complement a type unit if the member unit `group` does not have one. One member unit group has the same [TypeName](#P-Vsxmd.Units.MemberUnit.TypeName).
 
 ##### Returns
 
@@ -940,7 +943,7 @@ Param unit.
 
 ##### Summary
 
-Initializes a new instance of the `ParamUnit` class.
+Initializes a new instance of the [ParamUnit](#T-Vsxmd.Units.ParamUnit) class.
 
 ##### Parameters
 
@@ -989,7 +992,7 @@ The generated Markdown.
 
 When the parameter (a.k.a `elements`) list is empty:
 
-If parent element kind is `Constructor` or `Method`, it returns a hint about "no parameters".
+If parent element kind is [Constructor](#F-Vsxmd.Units.MemberKind.Constructor) or [Method](#F-Vsxmd.Units.MemberKind.Method), it returns a hint about "no parameters".
 
 If parent element kind is not the value mentioned above, it returns an empty string.
 
@@ -1009,7 +1012,7 @@ Permission unit.
 
 ##### Summary
 
-Initializes a new instance of the `PermissionUnit` class.
+Initializes a new instance of the [PermissionUnit](#T-Vsxmd.Units.PermissionUnit) class.
 
 ##### Parameters
 
@@ -1109,7 +1112,7 @@ Remarks unit.
 
 ##### Summary
 
-Initializes a new instance of the `RemarksUnit` class.
+Initializes a new instance of the [RemarksUnit](#T-Vsxmd.Units.RemarksUnit) class.
 
 ##### Parameters
 
@@ -1167,7 +1170,7 @@ Returns unit.
 
 ##### Summary
 
-Initializes a new instance of the `ReturnsUnit` class.
+Initializes a new instance of the [ReturnsUnit](#T-Vsxmd.Units.ReturnsUnit) class.
 
 ##### Parameters
 
@@ -1225,7 +1228,7 @@ Seealso unit.
 
 ##### Summary
 
-Initializes a new instance of the `SeealsoUnit` class.
+Initializes a new instance of the [SeealsoUnit](#T-Vsxmd.Units.SeealsoUnit) class.
 
 ##### Parameters
 
@@ -1283,7 +1286,7 @@ Summary unit.
 
 ##### Summary
 
-Initializes a new instance of the `SummaryUnit` class.
+Initializes a new instance of the [SummaryUnit](#T-Vsxmd.Units.SummaryUnit) class.
 
 ##### Parameters
 
@@ -1341,7 +1344,7 @@ Table of contents.
 
 ##### Summary
 
-Initializes a new instance of the `TableOfContents` class.
+Initializes a new instance of the [TableOfContents](#T-Vsxmd.TableOfContents) class.
 
 It convert the table of contents from the `memberUnits`.
 
@@ -1385,11 +1388,11 @@ Vsxmd.Program
 
 ##### Summary
 
-Initializes a new instance of the `Test` class.
+Initializes a new instance of the [Test](#T-Vsxmd.Program.Test) class.
 
 Test constructor without parameters.
 
-See `#ctor`
+See [Test.#ctor](#M-Vsxmd.Program.Test.#ctor)
 
 ##### Parameters
 
@@ -1491,7 +1494,7 @@ This method has no parameters.
 
 Test generic reference type.
 
-See ```TestGenericParameter``2```.
+See [TestGenericParameter\`\`2](#M-Vsxmd.Program.Test.TestGenericParameter``2-System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}}-).
 
 ##### Returns
 
@@ -1512,7 +1515,7 @@ Vsxmd.Program
 
 Test generic type.
 
-See ``TestGenericType`2``.
+See [TestGenericType\`2](#T-Vsxmd.Program.TestGenericType`2).
 
 ##### Generic Types
 
@@ -1528,7 +1531,7 @@ See ``TestGenericType`2``.
 
 Test generic method.
 
-See ```TestGenericMethod``2```
+See [TestGenericMethod\`\`2](#M-Vsxmd.Program.TestGenericType`2.TestGenericMethod``2)
 
 ##### Returns
 
@@ -1561,7 +1564,7 @@ Typeparam unit.
 
 ##### Summary
 
-Initializes a new instance of the `TypeparamUnit` class.
+Initializes a new instance of the [TypeparamUnit](#T-Vsxmd.Units.TypeparamUnit) class.
 
 ##### Parameters
 

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -26,7 +26,6 @@
 - [Extensions](#T-Vsxmd.Units.Extensions)
   - [AsCode](#M-Vsxmd.Units.Extensions.AsCode-System.String-)
   - [Escape](#M-Vsxmd.Units.Extensions.Escape-System.String-)
-  - [GetParamTypes](#M-Vsxmd.Units.Extensions.GetParamTypes-System.String-)
   - [Join](#M-Vsxmd.Units.Extensions.Join-System.Collections.Generic.IEnumerable{System.String},System.String-)
   - [NthLast\`\`1](#M-Vsxmd.Units.Extensions.NthLast``1-System.Collections.Generic.IEnumerable{``0},System.Int32-)
   - [TakeAllButLast\`\`1](#M-Vsxmd.Units.Extensions.TakeAllButLast``1-System.Collections.Generic.IEnumerable{``0},System.Int32-)
@@ -34,7 +33,6 @@
   - [ToHereLink](#M-Vsxmd.Units.Extensions.ToHereLink-System.String-)
   - [ToLowerString](#M-Vsxmd.Units.Extensions.ToLowerString-Vsxmd.Units.MemberKind-)
   - [ToMarkdownText](#M-Vsxmd.Units.Extensions.ToMarkdownText-System.Xml.Linq.XElement-)
-  - [ToNameSegments](#M-Vsxmd.Units.Extensions.ToNameSegments-System.String-)
   - [ToReferenceLink](#M-Vsxmd.Units.Extensions.ToReferenceLink-System.String,System.Boolean-)
 - [IUnit](#T-Vsxmd.Units.IUnit)
   - [ToMarkdown](#M-Vsxmd.Units.IUnit.ToMarkdown)
@@ -47,12 +45,17 @@
   - [Type](#F-Vsxmd.Units.MemberKind.Type)
 - [MemberName](#T-Vsxmd.Units.MemberName)
   - [#ctor](#M-Vsxmd.Units.MemberName.#ctor-System.String-)
+  - [Caption](#P-Vsxmd.Units.MemberName.Caption)
   - [Kind](#P-Vsxmd.Units.MemberName.Kind)
+  - [Link](#P-Vsxmd.Units.MemberName.Link)
+  - [Namespace](#P-Vsxmd.Units.MemberName.Namespace)
+  - [TypeName](#P-Vsxmd.Units.MemberName.TypeName)
+  - [CompareTo](#M-Vsxmd.Units.MemberName.CompareTo-Vsxmd.Units.MemberName-)
+  - [GetParamTypes](#M-Vsxmd.Units.MemberName.GetParamTypes)
   - [ToReferenceLink](#M-Vsxmd.Units.MemberName.ToReferenceLink-System.Boolean-)
 - [MemberUnit](#T-Vsxmd.Units.MemberUnit)
   - [#ctor](#M-Vsxmd.Units.MemberUnit.#ctor-System.Xml.Linq.XElement-)
   - [Comparer](#P-Vsxmd.Units.MemberUnit.Comparer)
-  - [FriendlyName](#P-Vsxmd.Units.MemberUnit.FriendlyName)
   - [Kind](#P-Vsxmd.Units.MemberUnit.Kind)
   - [Link](#P-Vsxmd.Units.MemberUnit.Link)
   - [TypeName](#P-Vsxmd.Units.MemberUnit.TypeName)
@@ -461,33 +464,6 @@ The escaped content.
 | ---- | ---- | ----------- |
 | content | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The content. |
 
-<a name='M-Vsxmd.Units.Extensions.GetParamTypes-System.String-'></a>
-### GetParamTypes `method` [#](#M-Vsxmd.Units.Extensions.GetParamTypes-System.String-) [^](#contents)
-
-##### Summary
-
-Gets the method parameter type names from the member unit `name`.
-
-##### Returns
-
-The method parameter type name list.
-
-##### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The member unit name. |
-
-##### Example
-
-It will prepend the type kind character (`T:`) to the type string.
-
-For `(System.String,System.Int32)`, returns `["T:System.String","T:System.Int32"]`.
-
-It also handle generic type.
-
-For `(System.Collections.Generic.IEnumerable{System.String})`, returns `["T:System.Collections.Generic.IEnumerable{System.String}"]`.
-
 <a name='M-Vsxmd.Units.Extensions.Join-System.Collections.Generic.IEnumerable{System.String},System.String-'></a>
 ### Join `method` [#](#M-Vsxmd.Units.Extensions.Join-System.Collections.Generic.IEnumerable{System.String},System.String-) [^](#contents)
 
@@ -636,27 +612,6 @@ To the below Markdown content.
 The `element` value is `null`, it throws `ArgumentException`. For more, see `ToMarkdownText`.
 ```
 
-<a name='M-Vsxmd.Units.Extensions.ToNameSegments-System.String-'></a>
-### ToNameSegments `method` [#](#M-Vsxmd.Units.Extensions.ToNameSegments-System.String-) [^](#contents)
-
-##### Summary
-
-Split the member unit `name` to segments.
-
-##### Returns
-
-The name segments.
-
-##### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The member unit name. |
-
-##### Example
-
-Split `M:Vsxmd.Converter.#ctor(System.String)` to `["Vsxmd", "Converter", "#ctor"]` string list.
-
 <a name='M-Vsxmd.Units.Extensions.ToReferenceLink-System.String,System.Boolean-'></a>
 ### ToReferenceLink `method` [#](#M-Vsxmd.Units.Extensions.ToReferenceLink-System.String,System.Boolean-) [^](#contents)
 
@@ -784,12 +739,90 @@ Initializes a new instance of the [MemberName](#T-Vsxmd.Units.MemberName) class.
 | ---- | ---- | ----------- |
 | name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String) | The raw member name. For example, `T:Vsxmd.Units.MemberName`. |
 
+<a name='P-Vsxmd.Units.MemberName.Caption'></a>
+### Caption `property` [#](#P-Vsxmd.Units.MemberName.Caption) [^](#contents)
+
+##### Summary
+
+Gets the caption representation for this member name.
+
+##### Example
+
+For [Type](#F-Vsxmd.Units.MemberKind.Type), show as `## Vsxmd.Units.MemberName [#](#here) [^](#contents)`.
+
+For other kinds, show as `### Vsxmd.Units.MemberName.Caption [#](#here) [^](#contents)`.
+
 <a name='P-Vsxmd.Units.MemberName.Kind'></a>
 ### Kind `property` [#](#P-Vsxmd.Units.MemberName.Kind) [^](#contents)
 
 ##### Summary
 
 Gets the member kind, one of [MemberKind](#T-Vsxmd.Units.MemberKind).
+
+<a name='P-Vsxmd.Units.MemberName.Link'></a>
+### Link `property` [#](#P-Vsxmd.Units.MemberName.Link) [^](#contents)
+
+##### Summary
+
+Gets the link pointing to this member unit.
+
+<a name='P-Vsxmd.Units.MemberName.Namespace'></a>
+### Namespace `property` [#](#P-Vsxmd.Units.MemberName.Namespace) [^](#contents)
+
+##### Summary
+
+Gets the namespace name.
+
+##### Example
+
+`System`, `Vsxmd`, `Vsxmd.Units`.
+
+<a name='P-Vsxmd.Units.MemberName.TypeName'></a>
+### TypeName `property` [#](#P-Vsxmd.Units.MemberName.TypeName) [^](#contents)
+
+##### Summary
+
+Gets the type name.
+
+##### Example
+
+`Vsxmd.Program`, `Vsxmd.Units.TypeUnit`.
+
+<a name='M-Vsxmd.Units.MemberName.CompareTo-Vsxmd.Units.MemberName-'></a>
+### CompareTo `method` [#](#M-Vsxmd.Units.MemberName.CompareTo-Vsxmd.Units.MemberName-) [^](#contents)
+
+##### Summary
+
+*Inherit from parent.*
+
+##### Parameters
+
+This method has no parameters.
+
+<a name='M-Vsxmd.Units.MemberName.GetParamTypes'></a>
+### GetParamTypes `method` [#](#M-Vsxmd.Units.MemberName.GetParamTypes) [^](#contents)
+
+##### Summary
+
+Gets the method parameter type names from the member name.
+
+##### Returns
+
+The method parameter type name list.
+
+##### Parameters
+
+This method has no parameters.
+
+##### Example
+
+It will prepend the type kind character (`T:`) to the type string.
+
+For `(System.String,System.Int32)`, returns `["T:System.String","T:System.Int32"]`.
+
+It also handle generic type.
+
+For `(System.Collections.Generic.IEnumerable{System.String})`, returns `["T:System.Collections.Generic.IEnumerable{System.String}"]`.
 
 <a name='M-Vsxmd.Units.MemberName.ToReferenceLink-System.Boolean-'></a>
 ### ToReferenceLink `method` [#](#M-Vsxmd.Units.MemberName.ToReferenceLink-System.Boolean-) [^](#contents)
@@ -848,13 +881,6 @@ Initializes a new instance of the [MemberUnit](#T-Vsxmd.Units.MemberUnit) class.
 ##### Summary
 
 Gets the member unit comparer.
-
-<a name='P-Vsxmd.Units.MemberUnit.FriendlyName'></a>
-### FriendlyName `property` [#](#P-Vsxmd.Units.MemberUnit.FriendlyName) [^](#contents)
-
-##### Summary
-
-Gets the user friendly name for the member. This name will be shown as caption.
 
 <a name='P-Vsxmd.Units.MemberUnit.Kind'></a>
 ### Kind `property` [#](#P-Vsxmd.Units.MemberUnit.Kind) [^](#contents)

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -44,6 +44,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Vsxmd.Program.Test"/> class.
             <para>Test constructor without parameters.</para>
+            <para>See <see cref="M:Vsxmd.Program.Test.#ctor"/></para>
             </summary>
         </member>
         <member name="M:Vsxmd.Program.Test.TestGenericRefence">
@@ -56,6 +57,7 @@
         <member name="M:Vsxmd.Program.Test.TestGenericParameter``2(System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}})">
             <summary>
             Test generic parameter type.
+            <para>See <typeparamref name="T1"/> and <typeparamref name="T2"/>.</para>
             </summary>
             <typeparam name="T1">Generic type 1.</typeparam>
             <typeparam name="T2">Generic type 2.</typeparam>
@@ -83,6 +85,23 @@
             <para>See <c>`backtick inside code block`</c></para>
             <para>See `<c>code block inside backtick</c>`</para>
             </summary>
+            <returns>Nothing.</returns>
+        </member>
+        <member name="T:Vsxmd.Program.TestGenericType`2">
+            <summary>
+            Test generic type.
+            <para>See <see cref="T:Vsxmd.Program.TestGenericType`2"/>.</para>
+            </summary>
+            <typeparam name="T1">Generic type 1.</typeparam>
+            <typeparam name="T2">Generic type 2.</typeparam>
+        </member>
+        <member name="M:Vsxmd.Program.TestGenericType`2.TestGenericMethod``2">
+            <summary>
+            Test generic method.
+            <para>See <see cref="M:Vsxmd.Program.TestGenericType`2.TestGenericMethod``2"/></para>
+            </summary>
+            <typeparam name="T3">Generic type 3.</typeparam>
+            <typeparam name="T4">Generic type 4.</typeparam>
             <returns>Nothing.</returns>
         </member>
         <member name="T:Vsxmd.TableOfContents">

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -314,6 +314,12 @@
             </summary>
             <param name="name">The member unit name.</param>
             <returns>The method parameter type name list.</returns>
+            <example>
+            It will prepend the type kind character (<c>T:</c>) to the type string.
+            <para>For <c>(System.String,System.Int32)</c>, returns <c>["T:System.String","T:System.Int32"]</c>.</para>
+            It also handle generic type.
+            <para>For <c>(System.Collections.Generic.IEnumerable{System.String})</c>, returns <c>["T:System.Collections.Generic.IEnumerable{System.String}"]</c>.</para>
+            </example>
         </member>
         <member name="M:Vsxmd.Units.Extensions.NthLast``1(System.Collections.Generic.IEnumerable{``0},System.Int32)">
             <summary>

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -280,6 +280,17 @@
             <param name="href">The href.</param>
             <returns>The "to here" link for the <paramref name="href"/>.</returns>
         </member>
+        <member name="M:Vsxmd.Units.Extensions.ToReferenceLink(System.String)">
+            <summary>
+            Generate the reference link for the <paramref name="memberName"/>.
+            </summary>
+            <param name="memberName">The member name.</param>
+            <returns>The generated reference link.</returns>
+            <example>
+            <para>For <c>T:Vsxmd.Units.MemberUnit</c>, convert it to <c>[MemberUnit](#T-Vsxmd.Units.MemberUnit)</c>.</para>
+            <para>For <c>T:System.ArgumentException</c>, convert it to <c>[ArgumentException](http://msdn/path/to/System.ArgumentException)</c>.</para>
+            </example>
+        </member>
         <member name="M:Vsxmd.Units.Extensions.AsCode(System.String)">
             <summary>
             Wrap the <paramref name="code"/> into Markdown backtick safely.
@@ -385,6 +396,31 @@
             <summary>
             Method.
             </summary>
+        </member>
+        <member name="T:Vsxmd.Units.MemberName">
+            <summary>
+            Member name.
+            </summary>
+        </member>
+        <member name="M:Vsxmd.Units.MemberName.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Vsxmd.Units.MemberName"/> class.
+            </summary>
+            <param name="name">The raw member name. For example, <c>T:Vsxmd.Units.MemberName</c>.</param>
+        </member>
+        <member name="P:Vsxmd.Units.MemberName.Kind">
+            <summary>
+            Gets the member kind, one of <see cref="T:Vsxmd.Units.MemberKind"/>.
+            </summary>
+            <value>The member kind.</value>
+        </member>
+        <member name="M:Vsxmd.Units.MemberName.ToReferenceLink">
+            <summary>
+            Convert the member name to Markdown reference link.
+            <para>If then name is under <c>System</c> namespace, the link points to MSDN.</para>
+            <para>Otherwise, the link points to this page anchor.</para>
+            </summary>
+            <returns>The generated Markdown reference link.</returns>
         </member>
         <member name="T:Vsxmd.Units.MemberUnit">
             <summary>

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -280,11 +280,12 @@
             <param name="href">The href.</param>
             <returns>The "to here" link for the <paramref name="href"/>.</returns>
         </member>
-        <member name="M:Vsxmd.Units.Extensions.ToReferenceLink(System.String)">
+        <member name="M:Vsxmd.Units.Extensions.ToReferenceLink(System.String,System.Boolean)">
             <summary>
             Generate the reference link for the <paramref name="memberName"/>.
             </summary>
             <param name="memberName">The member name.</param>
+            <param name="useShortName">Indicate if use short type name.</param>
             <returns>The generated reference link.</returns>
             <example>
             <para>For <c>T:Vsxmd.Units.MemberUnit</c>, convert it to <c>[MemberUnit](#T-Vsxmd.Units.MemberUnit)</c>.</para>
@@ -420,12 +421,13 @@
             </summary>
             <value>The member kind.</value>
         </member>
-        <member name="M:Vsxmd.Units.MemberName.ToReferenceLink">
+        <member name="M:Vsxmd.Units.MemberName.ToReferenceLink(System.Boolean)">
             <summary>
             Convert the member name to Markdown reference link.
             <para>If then name is under <c>System</c> namespace, the link points to MSDN.</para>
             <para>Otherwise, the link points to this page anchor.</para>
             </summary>
+            <param name="useShortName">Indicate if use short type name.</param>
             <returns>The generated Markdown reference link.</returns>
         </member>
         <member name="T:Vsxmd.Units.MemberUnit">

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -301,27 +301,6 @@
             <returns>The Markdwon code span.</returns>
             <remarks>Reference: http://meta.stackexchange.com/questions/55437/how-can-the-backtick-character-be-included-in-code </remarks>
         </member>
-        <member name="M:Vsxmd.Units.Extensions.ToNameSegments(System.String)">
-            <summary>
-            Split the member unit <paramref name="name"/> to segments.
-            </summary>
-            <param name="name">The member unit name.</param>
-            <returns>The name segments.</returns>
-            <example>Split <c>M:Vsxmd.Converter.#ctor(System.String)</c> to <c>["Vsxmd", "Converter", "#ctor"]</c> string list.</example>
-        </member>
-        <member name="M:Vsxmd.Units.Extensions.GetParamTypes(System.String)">
-            <summary>
-            Gets the method parameter type names from the member unit <paramref name="name"/>.
-            </summary>
-            <param name="name">The member unit name.</param>
-            <returns>The method parameter type name list.</returns>
-            <example>
-            It will prepend the type kind character (<c>T:</c>) to the type string.
-            <para>For <c>(System.String,System.Int32)</c>, returns <c>["T:System.String","T:System.Int32"]</c>.</para>
-            It also handle generic type.
-            <para>For <c>(System.Collections.Generic.IEnumerable{System.String})</c>, returns <c>["T:System.Collections.Generic.IEnumerable{System.String}"]</c>.</para>
-            </example>
-        </member>
         <member name="M:Vsxmd.Units.Extensions.NthLast``1(System.Collections.Generic.IEnumerable{``0},System.Int32)">
             <summary>
             Gets the n-th last element from the <paramref name="source"/>.
@@ -421,6 +400,51 @@
             </summary>
             <value>The member kind.</value>
         </member>
+        <member name="P:Vsxmd.Units.MemberName.Link">
+            <summary>
+            Gets the link pointing to this member unit.
+            </summary>
+            <value>The link pointing to this member unit.</value>
+        </member>
+        <member name="P:Vsxmd.Units.MemberName.Caption">
+            <summary>
+            Gets the caption representation for this member name.
+            </summary>
+            <value>The caption.</value>
+            <example>
+            <para>For <see cref="F:Vsxmd.Units.MemberKind.Type"/>, show as <c>## Vsxmd.Units.MemberName [#](#here) [^](#contents)</c>.</para>
+            <para>For other kinds, show as <c>### Vsxmd.Units.MemberName.Caption [#](#here) [^](#contents)</c>.</para>
+            </example>
+        </member>
+        <member name="P:Vsxmd.Units.MemberName.TypeName">
+            <summary>
+            Gets the type name.
+            </summary>
+            <value>The type name.</value>
+            <example><c>Vsxmd.Program</c>, <c>Vsxmd.Units.TypeUnit</c>.</example>
+        </member>
+        <member name="P:Vsxmd.Units.MemberName.Namespace">
+            <summary>
+            Gets the namespace name.
+            </summary>
+            <value>The namespace name.</value>
+            <example><c>System</c>, <c>Vsxmd</c>, <c>Vsxmd.Units</c>.</example>
+        </member>
+        <member name="M:Vsxmd.Units.MemberName.CompareTo(Vsxmd.Units.MemberName)">
+            <inheritdoc />
+        </member>
+        <member name="M:Vsxmd.Units.MemberName.GetParamTypes">
+            <summary>
+            Gets the method parameter type names from the member name.
+            </summary>
+            <returns>The method parameter type name list.</returns>
+            <example>
+            It will prepend the type kind character (<c>T:</c>) to the type string.
+            <para>For <c>(System.String,System.Int32)</c>, returns <c>["T:System.String","T:System.Int32"]</c>.</para>
+            It also handle generic type.
+            <para>For <c>(System.Collections.Generic.IEnumerable{System.String})</c>, returns <c>["T:System.Collections.Generic.IEnumerable{System.String}"]</c>.</para>
+            </example>
+        </member>
         <member name="M:Vsxmd.Units.MemberName.ToReferenceLink(System.Boolean)">
             <summary>
             Convert the member name to Markdown reference link.
@@ -466,13 +490,6 @@
             Gets the link pointing to this member unit.
             </summary>
             <value>The link pointing to this member unit.</value>
-        </member>
-        <member name="P:Vsxmd.Units.MemberUnit.FriendlyName">
-            <summary>
-            Gets the user friendly name for the member.
-            This name will be shown as caption.
-            </summary>
-            <value>The user friendly name for the member.</value>
         </member>
         <member name="M:Vsxmd.Units.MemberUnit.ToMarkdown">
             <inheritdoc />


### PR DESCRIPTION
- For types under `System` namespace, link them to MSDN pages.
- Otherwise, link them to local page anchors.
- Fix type caption escape issue.
- Refine `MemberUnit` to move logic to `MemberName` class.