### PR TITLE
Build refine

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -14,6 +14,13 @@
 
         <!-- Download NuGet.exe if it does not already exist -->
         <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">false</DownloadNuGetExe>
+
+        <!-- Use the nuspec file with the same project name if not specific -->
+        <NuspecPath Condition=" '$(NuspecPath)' == '' ">$(ProjectPath.Replace(".csproj", ".nuspec"))</NuspecPath>
+
+        <!-- Use AppVeyor build version as build version if available. Otherwise, set as 0.0.0.0 -->
+        <BuildVersion Condition=" '$(APPVEYOR_BUILD_VERSION)' != '' ">$(APPVEYOR_BUILD_VERSION)</BuildVersion>
+        <BuildVersion Condition=" '$(BuildVersion)' == '' ">0.0.0.0</BuildVersion>
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(PackageSources)' == '' ">
@@ -63,7 +70,7 @@
 
         <!-- Commands -->
         <RestoreCommand>$(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(NonInteractiveSwitch) $(RequireConsentSwitch) -solutionDir $(PaddedSolutionDir)</RestoreCommand>
-        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -symbols</BuildCommand>
+        <BuildCommand>$(NuGetCommand) pack "$(NuspecPath)" -Properties "Version=$(BuildVersion);Configuration=$(Configuration)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -symbols</BuildCommand>
 
         <!-- We need to ensure packages are restored prior to assembly resolve -->
         <BuildDependsOn Condition="$(RestorePackages) == 'true'">

--- a/Vsxmd/Program.cs
+++ b/Vsxmd/Program.cs
@@ -42,7 +42,7 @@ namespace Vsxmd
             string xmlPath = args[0];
             string markdownPath = args.ElementAtOrDefault(1);
 
-            if (markdownPath == null)
+            if (string.IsNullOrWhiteSpace(markdownPath))
             {
                 // replace the `xml` extension with `md` extension
                 markdownPath = Regex.Replace(xmlPath, @"\.xml$", ".md", RegexOptions.IgnoreCase);

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -18,6 +18,7 @@
     <RestorePackages>true</RestorePackages>
     <DownloadNuGetExe>true</DownloadNuGetExe>
     <BuildPackage>true</BuildPackage>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DocumentationFile>Vsxmd.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Vsxmd/Vsxmd.nuspec
+++ b/Vsxmd/Vsxmd.nuspec
@@ -1,20 +1,23 @@
 ﻿<?xml version="1.0"?>
 <package>
   <metadata>
-    <id>$id$</id>
-    <version>$version$</version>
-    <title>$title$</title>
-    <authors>$author$</authors>
-    <owners>$author$</owners>
+    <id>Vsxmd</id>
+    <version>$Version$</version>
+    <title>Vsxmd</title>
+    <authors>Junle Li</authors>
+    <owners>Junle Li</owners>
     <licenseUrl>https://github.com/lijunle/Vsxmd/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/lijunle/Vsxmd</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>$description$</description>
+    <description>VS XML documentation -> Markdown syntax.</description>
     <copyright>Copyright 2015</copyright>
     <developmentDependency>true</developmentDependency>
     <tags>Vsxmd VS XML document Markdown</tags>
   </metadata>
   <files>
     <file src="targets\*" target="build" />
+    <file src="bin\$Configuration$\Vsxmd.exe" target="tools" />
+    <file src="bin\$Configuration$\Vsxmd.pdb" target="tools" />
+    <file src="**\*.cs" target="src" exclude="obj\**\*.cs;bin\**\*.cs" />
   </files>
 </package>

--- a/Vsxmd/targets/Vsxmd.targets
+++ b/Vsxmd/targets/Vsxmd.targets
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VsxmdCommand>"$(MSBuildThisFileDirectory)\..\tools\Vsxmd.exe" "$(DocumentationFile)" "$(DocumentationMarkdown)"</VsxmdCommand>
+  </PropertyGroup>
   <Target Name="Vsxmd" AfterTargets="Build">
     <Message Text="Vsxmd starts to convert XML to Markdown." />
     <Error Condition=" '$(DocumentationFile)' == '' " Text="Project has not configure to output XML documentation file." />
-    <Exec Command=" &quot;$(MSBuildThisFileDirectory)\..\tools\Vsxmd.exe&quot; &quot;$(DocumentationFile)&quot; " />
+    <Exec Command="$(VsxmdCommand)" />
     <Message Text="Vsxmd finishs conversion." />
   </Target>
 </Project>

--- a/Vsxmd/targets/Vsxmd.targets
+++ b/Vsxmd/targets/Vsxmd.targets
@@ -3,7 +3,7 @@
   <Target Name="Vsxmd" AfterTargets="Build">
     <Message Text="Vsxmd starts to convert XML to Markdown." />
     <Error Condition=" '$(DocumentationFile)' == '' " Text="Project has not configure to output XML documentation file." />
-    <Exec Command=" &quot;$(MSBuildThisFileDirectory)\..\lib\net452\Vsxmd.exe&quot; &quot;$(DocumentationFile)&quot; " />
+    <Exec Command=" &quot;$(MSBuildThisFileDirectory)\..\tools\Vsxmd.exe&quot; &quot;$(DocumentationFile)&quot; " />
     <Message Text="Vsxmd finishs conversion." />
   </Target>
 </Project>


### PR DESCRIPTION
- Pack nuget package from nuspec directly, resolve #2 
- Add targets option, `DocumentationMarkdown`, to control Markdown output file path
- Treat all build warning as errors.