### PR TITLE
Fix throwing exception when param description is empty.

### DIFF
--- a/Vsxmd/Program.cs
+++ b/Vsxmd/Program.cs
@@ -66,6 +66,15 @@ namespace Vsxmd
             {
             }
 
+#pragma warning disable SA1614 // Element parameter documentation must have text
+            /// <summary>
+            /// Test a param tag without description.
+            /// </summary>
+            /// <param name="p"></param>
+            /// <returns>Nothing.</returns>
+            internal string TestParamWithoutDescription(string p) => null;
+#pragma warning restore SA1614 // Element parameter documentation must have text
+
             /// <summary>
             /// Test generic reference type.
             /// <para>See <see cref="TestGenericParameter{T1, T2}(Expression{Func{T1, T2, string}})"/>.</para>

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -141,12 +141,7 @@ namespace Vsxmd.Units
         internal static string ToMarkdownText(this XElement element) =>
             element.Nodes()
                 .Select(ToMarkdownSpan)
-                .Aggregate((x, y) =>
-                    x.EndsWith("\n\n")
-                        ? $"{x}{y.TrimStart()}"
-                        : y.StartsWith("\n\n")
-                        ? $"{x.TrimEnd()}{y}"
-                        : $"{x}{y}")
+                .Aggregate(string.Empty, JoinMarkdownSpan)
                 .Trim();
 
         private static string ToMarkdownSpan(XNode node)
@@ -181,5 +176,12 @@ namespace Vsxmd.Units
 
             return string.Empty;
         }
+
+        private static string JoinMarkdownSpan(string x, string y) =>
+            x.EndsWith("\n\n")
+                ? $"{x}{y.TrimStart()}"
+                : y.StartsWith("\n\n")
+                ? $"{x.TrimEnd()}{y}"
+                : $"{x}{y}";
     }
 }

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -105,6 +105,7 @@
   - [TestGenericParameter\`\`2(expression)](#M-Vsxmd.Program.Test.TestGenericParameter``2-System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}}- 'Vsxmd.Program.Test.TestGenericParameter``2(System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}})')
   - [TestGenericPermission()](#M-Vsxmd.Program.Test.TestGenericPermission 'Vsxmd.Program.Test.TestGenericPermission')
   - [TestGenericRefence()](#M-Vsxmd.Program.Test.TestGenericRefence 'Vsxmd.Program.Test.TestGenericRefence')
+  - [TestParamWithoutDescription(p)](#M-Vsxmd.Program.Test.TestParamWithoutDescription-System.String- 'Vsxmd.Program.Test.TestParamWithoutDescription(System.String)')
 - [TestGenericType\`2](#T-Vsxmd.Program.TestGenericType`2 'Vsxmd.Program.TestGenericType`2')
   - [TestGenericMethod\`\`2()](#M-Vsxmd.Program.TestGenericType`2.TestGenericMethod``2 'Vsxmd.Program.TestGenericType`2.TestGenericMethod``2')
 - [TypeparamUnit](#T-Vsxmd.Units.TypeparamUnit 'Vsxmd.Units.TypeparamUnit')
@@ -1605,6 +1606,23 @@ Nothing.
 ##### Parameters
 
 This method has no parameters.
+
+<a name='M-Vsxmd.Program.Test.TestParamWithoutDescription-System.String-'></a>
+### TestParamWithoutDescription(p) `method` [#](#M-Vsxmd.Program.Test.TestParamWithoutDescription-System.String- 'Go To Here') [^](#contents 'Back To Contents')
+
+##### Summary
+
+Test a param tag without description.
+
+##### Returns
+
+Nothing.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| p | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='T-Vsxmd.Program.TestGenericType`2'></a>
 ## TestGenericType\`2 [#](#T-Vsxmd.Program.TestGenericType`2 'Go To Here') [^](#contents 'Back To Contents')

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -60,6 +60,13 @@
             </summary>
             <permission cref="T:System.Security.PermissionSet">Just for test.</permission>
         </member>
+        <member name="M:Vsxmd.Program.Test.TestParamWithoutDescription(System.String)">
+            <summary>
+            Test a param tag without description.
+            </summary>
+            <param name="p"></param>
+            <returns>Nothing.</returns>
+        </member>
         <member name="M:Vsxmd.Program.Test.TestGenericRefence">
             <summary>
             Test generic reference type.


### PR DESCRIPTION
- Add false test case.
- Resolve #18