### PR TITLE
Typos in Vsxmd.targets (MSBuild integration) messages

### DIFF
--- a/Vsxmd/targets/Vsxmd.targets
+++ b/Vsxmd/targets/Vsxmd.targets
@@ -7,6 +7,6 @@
     <Message Text="Vsxmd starts to convert XML to Markdown." />
     <Error Condition=" '$(DocumentationFile)' == '' " Text="Project has not configure to output XML documentation file." />
     <Exec Command="$(VsxmdCommand)" />
-    <Message Text="Vsxmd finishs conversion." />
+    <Message Text="Vsxmd finishes conversion." />
   </Target>
 </Project>

--- a/Vsxmd/targets/Vsxmd.targets
+++ b/Vsxmd/targets/Vsxmd.targets
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <Target Name="Vsxmd" AfterTargets="Build">
     <Message Text="Vsxmd starts to convert XML to Markdown." />
-    <Error Condition=" '$(DocumentationFile)' == '' " Text="Project has not configure to output XML documentation file." />
+    <Error Condition=" '$(DocumentationFile)' == '' " Text="Project not configured to output XML documentation file." />
     <Exec Command="$(VsxmdCommand)" />
     <Message Text="Vsxmd finishes conversion." />
   </Target>


### PR DESCRIPTION
P.S. I think due to line-ending normalization incompatibility (as none is specified for the repo via `.gitattributes`), you may notice larger diffs than the actual changes.