### PR TITLE
Use BCL API to change extension instead of Regex

### DIFF
--- a/Vsxmd/Program.cs
+++ b/Vsxmd/Program.cs
@@ -11,7 +11,6 @@ namespace Vsxmd
     using System.Linq;
     using System.Linq.Expressions;
     using System.Security;
-    using System.Text.RegularExpressions;
     using System.Xml.Linq;
 
     /// <summary>
@@ -43,8 +42,8 @@ namespace Vsxmd
 
             if (string.IsNullOrWhiteSpace(markdownPath))
             {
-                // replace the `xml` extension with `md` extension
-                markdownPath = Regex.Replace(xmlPath, @"\.xml$", ".md", RegexOptions.IgnoreCase);
+                // replace extension with `md` extension
+                markdownPath = Path.ChangeExtension(xmlPath, ".md");
             }
 
             var document = XDocument.Load(xmlPath);


### PR DESCRIPTION
Using [`Path.ChangeExtension`](https://msdn.microsoft.com/en-us/library/system.io.path.changeextension(v=vs.110).aspx) to replace the extension:

```c#
// replace extension with `md` extension
markdownPath = Path.ChangeExtension(xmlPath, ".md");
```

`Regex` seemed a bit of an overkill for this:

```c#
// replace the `xml` extension with `md` extension
markdownPath = Regex.Replace(xmlPath, @"\.xml$", ".md", RegexOptions.IgnoreCase);
```

