### PR TITLE
Use version ref in nuspec.

### DIFF
--- a/Vsxmd/Vsxmd.nuspec
+++ b/Vsxmd/Vsxmd.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Vsxmd</id>
-    <version>1.3.3</version>
+    <version>$version$</version>
     <title>Vsxmd</title>
     <authors>Junle Li, Sales Lessa Lopes</authors>
     <owners>Junle Li, Sales Lessa Lopes</owners>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,3 +39,17 @@ nuget:
   project_feed: false
   disable_publish_on_pr: true
 
+deploy:
+  - release: v$(APPVEYOR_BUILD_VERSION)
+    provider: GitHub
+    draft: false
+    prerelease: false
+    auth_token:
+      secure: cApkFZuYfz7loLotMfbhb53ZIfjjfbY7dr46eu6Q9+yAV+KuSGYGcVTG8Bgx8wka
+    on:
+      appveyor_repo_tag: true
+  - provider: NuGet
+    api_key:
+      secure: iBKdOaX4b1BDwWzGKoqbHoJHyOAxL6EHCRIretKb16QRLm5l1nkaF+W0SGfuEfMY
+    on:
+      appveyor_repo_tag: true


### PR DESCRIPTION
Correct the git tag naming convention.

The assembly info is patched from git tag name [via AppVeyor](https://www.appveyor.com/docs/build-configuration/#assemblyinfo-patching). Then, the `.nuspec` use the assembly version [as nuget version](https://docs.microsoft.com/en-us/nuget/reference/nuspec#replacement-tokens).

/cc @saleslessa 