### PR TITLE
Introduce the code analyzers to project and fix the violations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,7 +164,6 @@ AppPackages/
 
 # Others
 ClientBin/
-[Ss]tyle[Cc]op.*
 ~$*
 *~
 *.dbmdl

--- a/Vsxmd/Converter.cs
+++ b/Vsxmd/Converter.cs
@@ -9,7 +9,7 @@ namespace Vsxmd
     using System.Collections.Generic;
     using System.Linq;
     using System.Xml.Linq;
-    using Units;
+    using Vsxmd.Units;
 
     /// <inheritdoc/>
     public class Converter : IConverter

--- a/Vsxmd/GlobalSuppressions.cs
+++ b/Vsxmd/GlobalSuppressions.cs
@@ -4,4 +4,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = ".Net Framework not supports StirngComparison parameter for some string methods yet.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307: Specify StringComparison", Justification = ".Net Framework not supports StirngComparison parameter for some string methods yet.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812: Avoid uninstantiated internal classes", Justification = "The uninstantiated internal class is for unit testing the XML documentation.", Scope = "type", Target = "~T:Vsxmd.Program.Test")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812: Avoid uninstantiated internal classes", Justification = "The uninstantiated internal class is for unit testing the XML documentation.", Scope = "type", Target = "~T:Vsxmd.Program.TestGenericType`2")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1801: Review unused parameters", Justification = "The unused parameter is for unit testing the XML documentation.", Scope = "member", Target = "~M:Vsxmd.Program.Test.TestGenericParameter``2(System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}})")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1801: Review unused parameters", Justification = "The unused parameter is for unit testing the XML documentation.", Scope = "member", Target = "~M:Vsxmd.Program.Test.TestParamWithoutDescription(System.String)")]

--- a/Vsxmd/GlobalSuppressions.cs
+++ b/Vsxmd/GlobalSuppressions.cs
@@ -4,7 +4,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+#if NETCOREAPP2_2
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307: Specify StringComparison", Justification = ".Net Framework not supports StirngComparison parameter for some string methods yet.")]
+#endif
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812: Avoid uninstantiated internal classes", Justification = "The uninstantiated internal class is for unit testing the XML documentation.", Scope = "type", Target = "~T:Vsxmd.Program.Test")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812: Avoid uninstantiated internal classes", Justification = "The uninstantiated internal class is for unit testing the XML documentation.", Scope = "type", Target = "~T:Vsxmd.Program.TestGenericType`2")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1801: Review unused parameters", Justification = "The unused parameter is for unit testing the XML documentation.", Scope = "member", Target = "~M:Vsxmd.Program.Test.TestGenericParameter``2(System.Linq.Expressions.Expression{System.Func{``0,``1,System.String}})")]

--- a/Vsxmd/GlobalSuppressions.cs
+++ b/Vsxmd/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="GlobalSuppressions.cs" company="Junle Li">
+//     Copyright (c) Junle Li. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = ".Net Framework not supports StirngComparison parameter for some string methods yet.")]

--- a/Vsxmd/Program.cs
+++ b/Vsxmd/Program.cs
@@ -7,6 +7,7 @@
 namespace Vsxmd
 {
     using System;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Linq.Expressions;
@@ -17,7 +18,7 @@ namespace Vsxmd
     /// </summary>
     /// <remarks>
     /// Usage syntax:
-    /// <c>Vsxmd.exe &lt;input-XML-path&gt; [output-Markdown-path]</c>
+    /// <code>Vsxmd.exe &lt;input-XML-path&gt; [output-Markdown-path]</code>
     /// <para>The <c>input-XML-path</c> argument is required. It references to the VS generated XML documentation file.</para>
     /// <para>The <c>output-Markdown-path</c> argument is optional. It indicates the file path for the Markdown output file. When not specific, it will be a <c>.md</c> file with same file name as the XML documentation file, path at the XML documentation folder.</para>
     /// </remarks>
@@ -58,7 +59,7 @@ namespace Vsxmd
                     return;
                 }
 
-                var shouldDelete = Convert.ToBoolean(vsxmdAutoDeleteXml);
+                var shouldDelete = Convert.ToBoolean(vsxmdAutoDeleteXml, CultureInfo.InvariantCulture);
                 if (shouldDelete)
                 {
                     File.Delete(xmlPath);
@@ -67,6 +68,7 @@ namespace Vsxmd
             catch (Exception e)
             {
                 Console.WriteLine(e.Message);
+
                 // Ignore errors. Do not impact on project build
                 return;
             }
@@ -77,7 +79,7 @@ namespace Vsxmd
             /// <summary>
             /// Initializes a new instance of the <see cref="Test"/> class.
             /// <para>Test constructor without parameters.</para>
-            /// <para>See <see cref="Test()"/></para>
+            /// <para>See <see cref="Test()"/>.</para>
             /// </summary>
             /// <permission cref="Program">Just for test.</permission>
             internal Test()
@@ -129,8 +131,8 @@ namespace Vsxmd
             /// <summary>
             /// Test backtick characters in summary comment.
             /// <para>See `should not inside code block`.</para>
-            /// <para>See <c>`backtick inside code block`</c></para>
-            /// <para>See `<c>code block inside backtick</c>`</para>
+            /// <para>See <c>`backtick inside code block`</c>.</para>
+            /// <para>See `<c>code block inside backtick</c>`.</para>
             /// </summary>
             /// <returns>Nothing.</returns>
             internal string TestBacktickInSummary() => null;
@@ -152,7 +154,7 @@ namespace Vsxmd
         {
             /// <summary>
             /// Test generic method.
-            /// <para>See <see cref="TestGenericMethod{T3, T4}"/></para>
+            /// <para>See <see cref="TestGenericMethod{T3, T4}"/>.</para>
             /// </summary>
             /// <typeparam name="T3">Generic type 3.</typeparam>
             /// <typeparam name="T4">Generic type 4.</typeparam>

--- a/Vsxmd/TableOfContents.cs
+++ b/Vsxmd/TableOfContents.cs
@@ -8,7 +8,7 @@ namespace Vsxmd
 {
     using System.Collections.Generic;
     using System.Linq;
-    using Units;
+    using Vsxmd.Units;
 
     /// <summary>
     /// Table of contents.
@@ -42,9 +42,8 @@ namespace Vsxmd
         public IEnumerable<string> ToMarkdown() =>
             new[]
             {
-
                 $"## Contents",
-                this.memberUnits.Select(ToMarkdown).Join("\n")
+                this.memberUnits.Select(ToMarkdown).Join("\n"),
             };
 
         private static string ToMarkdown(MemberUnit memberUnit) =>

--- a/Vsxmd/Units/AssemblyUnit.cs
+++ b/Vsxmd/Units/AssemblyUnit.cs
@@ -33,7 +33,7 @@ namespace Vsxmd.Units
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"{Href.ToAnchor()}# {this.AssemblyName}"
+                $"{Href.ToAnchor()}# {this.AssemblyName}",
             };
     }
 }

--- a/Vsxmd/Units/BaseUnit.cs
+++ b/Vsxmd/Units/BaseUnit.cs
@@ -25,7 +25,7 @@ namespace Vsxmd.Units
         {
             if (element.Name != elementName)
             {
-                throw new ArgumentException(nameof(element));
+                throw new ArgumentException("The element name is not expected", nameof(element));
             }
 
             this.Element = element;

--- a/Vsxmd/Units/ExampleUnit.cs
+++ b/Vsxmd/Units/ExampleUnit.cs
@@ -31,7 +31,7 @@ namespace Vsxmd.Units
             new[]
             {
                 $"##### Example",
-                $"{this.ElementContent}"
+                $"{this.ElementContent}",
             };
 
         /// <summary>

--- a/Vsxmd/Units/ExceptionUnit.cs
+++ b/Vsxmd/Units/ExceptionUnit.cs
@@ -34,7 +34,7 @@ namespace Vsxmd.Units
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"| {this.Name} | {this.Description} |"
+                $"| {this.Name} | {this.Description} |",
             };
 
         /// <summary>
@@ -57,14 +57,14 @@ namespace Vsxmd.Units
             var table = new[]
             {
                 "| Name | Description |",
-                "| ---- | ----------- |"
+                "| ---- | ----------- |",
             }
             .Concat(markdowns);
 
             return new[]
             {
                 "##### Exceptions",
-                string.Join("\n", table)
+                string.Join("\n", table),
             };
         }
     }

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -9,7 +9,6 @@ namespace Vsxmd.Units
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text.RegularExpressions;
     using System.Xml.Linq;
 
     /// <summary>

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -23,7 +23,9 @@ namespace Vsxmd.Units
         /// <param name="memberKind">The member kind.</param>
         /// <returns>The member kind's lowercase name.</returns>
         internal static string ToLowerString(this MemberKind memberKind) =>
-            memberKind.ToString().ToLower();
+#pragma warning disable CA1308 // We use lower case in URL anchor.
+            memberKind.ToString().ToLowerInvariant();
+#pragma warning restore CA1308
 
         /// <summary>
         /// Concatenates the <paramref name="value"/>s with the <paramref name="separator"/>.
@@ -86,7 +88,7 @@ namespace Vsxmd.Units
         /// </summary>
         /// <param name="code">The code span.</param>
         /// <returns>The Markdwon code span.</returns>
-        /// <remarks>Reference: http://meta.stackexchange.com/questions/55437/how-can-the-backtick-character-be-included-in-code </remarks>
+        /// <remarks>Reference: http://meta.stackexchange.com/questions/55437/how-can-the-backtick-character-be-included-in-code .</remarks>
         internal static string AsCode(this string code)
         {
             string backticks = "`";
@@ -95,7 +97,7 @@ namespace Vsxmd.Units
                 backticks += "`";
             }
 
-            return code.StartsWith("`") || code.EndsWith("`")
+            return code.StartsWith("`", StringComparison.Ordinal) || code.EndsWith("`", StringComparison.Ordinal)
                 ? $"{backticks} {code} {backticks}"
                 : $"{backticks}{code}{backticks}";
         }
@@ -128,10 +130,10 @@ namespace Vsxmd.Units
         /// For example, it works for <c>summary</c> and <c>returns</c> elements.
         /// </summary>
         /// <param name="element">The XML element.</param>
-        /// <param name="withLineBreak">Optional parameter to transform two spaces into a linebreak</param>
+        /// <param name="withLineBreak">Optional parameter to transform two spaces into a linebreak.</param>
         /// <returns>The generated Markdwon content.</returns>
         /// <example>
-        /// This method converts the following <c>summary</c> element
+        /// This method converts the following <c>summary</c> element.
         /// <code>
         /// <summary>The <paramref name="element" /> value is <value>null</value>, it throws <c>ArgumentException</c>. For more, see <see cref="ToMarkdownText(XElement, bool)"/>.</summary>
         /// </code>
@@ -151,7 +153,7 @@ namespace Vsxmd.Units
             var text = node as XText;
             if (text != null)
             {
-                return text.Value.Escape().TrimStart(' ').Replace("            ", "");
+                return text.Value.Escape().TrimStart(' ').Replace("            ", string.Empty);
             }
 
             var child = node as XElement;
@@ -214,9 +216,9 @@ namespace Vsxmd.Units
         }
 
         private static string JoinMarkdownSpan(string x, string y) =>
-            x.EndsWith("\n\n")
+            x.EndsWith("\n\n", StringComparison.Ordinal)
                 ? $"{x}{y.TrimStart()}"
-                : y.StartsWith("\n\n")
+                : y.StartsWith("\n\n", StringComparison.Ordinal)
                 ? $"{x.TrimEnd()}{y}"
                 : $"{x}{y}";
 

--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -130,19 +130,18 @@ namespace Vsxmd.Units
         /// For example, it works for <c>summary</c> and <c>returns</c> elements.
         /// </summary>
         /// <param name="element">The XML element.</param>
-        /// <param name="withLineBreak">Optional parameter to transform two spaces into a linebreak.</param>
         /// <returns>The generated Markdwon content.</returns>
         /// <example>
         /// This method converts the following <c>summary</c> element.
         /// <code>
-        /// <summary>The <paramref name="element" /> value is <value>null</value>, it throws <c>ArgumentException</c>. For more, see <see cref="ToMarkdownText(XElement, bool)"/>.</summary>
+        /// <summary>The <paramref name="element" /> value is <value>null</value>, it throws <c>ArgumentException</c>. For more, see <see cref="ToMarkdownText(XElement)"/>.</summary>
         /// </code>
         /// To the below Markdown content.
         /// <code>
         /// The `element` value is `null`, it throws `ArgumentException`. For more, see `ToMarkdownText`.
         /// </code>
         /// </example>
-        internal static string ToMarkdownText(this XElement element, bool withLineBreak = false) =>
+        internal static string ToMarkdownText(this XElement element) =>
             element.Nodes()
                 .Select(ToMarkdownSpan)
                 .Aggregate(string.Empty, JoinMarkdownSpan)

--- a/Vsxmd/Units/MemberKind.cs
+++ b/Vsxmd/Units/MemberKind.cs
@@ -39,6 +39,6 @@ namespace Vsxmd.Units
         /// <summary>
         /// Method.
         /// </summary>
-        Method
+        Method,
     }
 }

--- a/Vsxmd/Units/MemberName.cs
+++ b/Vsxmd/Units/MemberName.cs
@@ -157,10 +157,10 @@ namespace Vsxmd.Units
         /// <inheritdoc />
         public int CompareTo(MemberName other) =>
             this.TypeShortName != other.TypeShortName
-            ? this.TypeShortName.CompareTo(other.TypeShortName)
+            ? string.Compare(this.TypeShortName, other.TypeShortName, StringComparison.Ordinal)
             : this.Kind != other.Kind
             ? this.Kind.CompareTo(other.Kind)
-            : this.LongName.CompareTo(other.LongName);
+            : string.Compare(this.LongName, other.LongName, StringComparison.Ordinal);
 
         /// <summary>
         /// Gets the method parameter type names from the member name.
@@ -179,7 +179,7 @@ namespace Vsxmd.Units
             var delta = 0;
             var list = new List<StringBuilder>()
             {
-                new StringBuilder("T:")
+                new StringBuilder("T:"),
             };
 
             foreach (var character in paramString)
@@ -214,7 +214,7 @@ namespace Vsxmd.Units
         /// <param name="useShortName">Indicate if use short type name.</param>
         /// <returns>The generated Markdown reference link.</returns>
         internal string ToReferenceLink(bool useShortName) =>
-            $"{this.Namespace}.".StartsWith("System.")
+            $"{this.Namespace}.".StartsWith("System.", StringComparison.Ordinal)
             ? $"[{this.GetReferenceName(useShortName).Escape()}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:{this.MsdnName} '{this.StrippedName}')"
             : $"[{this.GetReferenceName(useShortName).Escape()}](#{this.Href} '{this.StrippedName}')";
 

--- a/Vsxmd/Units/MemberUnit.cs
+++ b/Vsxmd/Units/MemberUnit.cs
@@ -67,7 +67,7 @@ namespace Vsxmd.Units
                 : new[]
                 {
                     "##### Summary",
-                    "*Inherit from parent.*"
+                    "*Inherit from parent.*",
                 };
 
         private IEnumerable<string> Namespace =>
@@ -76,7 +76,7 @@ namespace Vsxmd.Units
             : new[]
             {
                 $"##### Namespace",
-                $"{this.name.Namespace}"
+                $"{this.name.Namespace}",
             };
 
         private IEnumerable<string> Summary =>
@@ -138,7 +138,8 @@ namespace Vsxmd.Units
 
         private static MemberUnit Create(string typeName) =>
             new MemberUnit(
-                new XElement("member",
+                new XElement(
+                    "member",
                     new XAttribute("name", $"T:{typeName}")));
 
         private class MemberUnitComparer : IComparer<MemberUnit>

--- a/Vsxmd/Units/ParamUnit.cs
+++ b/Vsxmd/Units/ParamUnit.cs
@@ -38,7 +38,7 @@ namespace Vsxmd.Units
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"| {this.Name} | {this.paramType.ToReferenceLink()} | {this.Description} |"
+                $"| {this.Name} | {this.paramType.ToReferenceLink()} | {this.Description} |",
             };
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Vsxmd.Units
                     : new[]
                     {
                         "##### Parameters",
-                        $"This {memberKind.ToLowerString()} has no parameters."
+                        $"This {memberKind.ToLowerString()} has no parameters.",
                     };
             }
 
@@ -78,14 +78,14 @@ namespace Vsxmd.Units
             var table = new[]
             {
                 "| Name | Type | Description |",
-                "| ---- | ---- | ----------- |"
+                "| ---- | ---- | ----------- |",
             }
             .Concat(markdowns);
 
             return new[]
             {
                 "##### Parameters",
-                string.Join("\n", table)
+                string.Join("\n", table),
             };
         }
     }

--- a/Vsxmd/Units/PermissionUnit.cs
+++ b/Vsxmd/Units/PermissionUnit.cs
@@ -34,7 +34,7 @@ namespace Vsxmd.Units
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"| {this.Name} | {this.Description} |"
+                $"| {this.Name} | {this.Description} |",
             };
 
         /// <summary>
@@ -57,14 +57,14 @@ namespace Vsxmd.Units
             var table = new[]
             {
                 "| Name | Description |",
-                "| ---- | ----------- |"
+                "| ---- | ----------- |",
             }
             .Concat(markdowns);
 
             return new[]
             {
                 "##### Permissions",
-                string.Join("\n", table)
+                string.Join("\n", table),
             };
         }
     }

--- a/Vsxmd/Units/RemarksUnit.cs
+++ b/Vsxmd/Units/RemarksUnit.cs
@@ -31,7 +31,7 @@ namespace Vsxmd.Units
             new[]
             {
                 "##### Remarks",
-                this.ElementContent
+                this.ElementContent,
             };
 
         /// <summary>

--- a/Vsxmd/Units/ReturnsUnit.cs
+++ b/Vsxmd/Units/ReturnsUnit.cs
@@ -31,7 +31,7 @@ namespace Vsxmd.Units
             new[]
             {
                 "##### Returns",
-                this.ElementContent
+                this.ElementContent,
             };
 
         /// <summary>

--- a/Vsxmd/Units/SeealsoUnit.cs
+++ b/Vsxmd/Units/SeealsoUnit.cs
@@ -30,7 +30,7 @@ namespace Vsxmd.Units
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"- {this.GetAttribute("cref").ToReferenceLink()}"
+                $"- {this.GetAttribute("cref").ToReferenceLink()}",
             };
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Vsxmd.Units
             return new[]
             {
                 "##### See Also",
-                string.Join("\n", markdowns)
+                string.Join("\n", markdowns),
             };
         }
     }

--- a/Vsxmd/Units/SummaryUnit.cs
+++ b/Vsxmd/Units/SummaryUnit.cs
@@ -31,7 +31,7 @@ namespace Vsxmd.Units
             new[]
             {
                 "##### Summary",
-                this.ElementContent
+                this.ElementContent,
             };
 
         /// <summary>

--- a/Vsxmd/Units/TypeparamUnit.cs
+++ b/Vsxmd/Units/TypeparamUnit.cs
@@ -34,7 +34,7 @@ namespace Vsxmd.Units
         public override IEnumerable<string> ToMarkdown() =>
             new[]
             {
-                $"| {this.Name} | {this.Description} |"
+                $"| {this.Name} | {this.Description} |",
             };
 
         /// <summary>
@@ -57,14 +57,14 @@ namespace Vsxmd.Units
             var table = new[]
             {
                 "| Name | Description |",
-                "| ---- | ----------- |"
+                "| ---- | ----------- |",
             }
             .Concat(markdowns);
 
             return new[]
             {
                 "##### Generic Types",
-                string.Join("\n", table)
+                string.Join("\n", table),
             };
         }
     }

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -8,6 +8,10 @@
     <DocumentationFile>Vsxmd.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -7,6 +7,13 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.2</TargetFrameworks>
     <DocumentationFile>Vsxmd.xml</DocumentationFile>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
 
   <!-- NuGet Metadata: https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#nuget-metadata-properties -->
   <PropertyGroup>

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -467,7 +467,7 @@ The Markdwon code span.
 
 ##### Remarks
 
-Reference: http://meta.stackexchange.com/questions/55437/how-can-the-backtick-character-be-included-in-code
+Reference: http://meta.stackexchange.com/questions/55437/how-can-the-backtick-character-be-included-in-code .
 
 <a name='M-Vsxmd-Units-Extensions-Escape-System-String-'></a>
 ### Escape(content) `method`
@@ -638,11 +638,11 @@ The generated Markdwon content.
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement 'System.Xml.Linq.XElement') | The XML element. |
-| withLineBreak | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | Optional parameter to transform two spaces into a linebreak |
+| withLineBreak | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | Optional parameter to transform two spaces into a linebreak. |
 
 ##### Example
 
-This method converts the following `summary`element
+This method converts the following `summary`element.
 
 ```
 <summary>The <paramref name="element" /> value is <value>null</value>, it throws <c>ArgumentException</c>. For more, see <see cref="M:Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement,System.Boolean)" />.</summary>
@@ -1178,7 +1178,10 @@ Program entry.
 ##### Remarks
 
 Usage syntax:
-`Vsxmd.exe <input-XML-path> [output-Markdown-path]`
+
+```
+Vsxmd.exe &lt;input-XML-path&gt; [output-Markdown-path]
+```
 
 The `input-XML-path`argument is required. It references to the VS generated XML documentation file.
 
@@ -1501,7 +1504,7 @@ Initializes a new instance of the [Test](#T-Vsxmd-Program-Test 'Vsxmd.Program.Te
 
 Test constructor without parameters.
 
-See [Test.#ctor](#M-Vsxmd-Program-Test-#ctor 'Vsxmd.Program.Test.#ctor')
+See [Test.#ctor](#M-Vsxmd-Program-Test-#ctor 'Vsxmd.Program.Test.#ctor').
 
 ##### Parameters
 
@@ -1522,9 +1525,9 @@ Test backtick characters in summary comment.
 
 See \`should not inside code block\`.
 
-See `` `backtick inside code block` ``
+See `` `backtick inside code block` ``.
 
-See \``code block inside backtick`\`
+See \``code block inside backtick`\`.
 
 ##### Returns
 
@@ -1678,7 +1681,7 @@ See [TestGenericType\`2](#T-Vsxmd-Program-TestGenericType`2 'Vsxmd.Program.TestG
 
 Test generic method.
 
-See [TestGenericMethod\`\`2](#M-Vsxmd-Program-TestGenericType`2-TestGenericMethod``2 'Vsxmd.Program.TestGenericType`2.TestGenericMethod``2')
+See [TestGenericMethod\`\`2](#M-Vsxmd-Program-TestGenericType`2-TestGenericMethod``2 'Vsxmd.Program.TestGenericType`2.TestGenericMethod``2').
 
 ##### Returns
 

--- a/Vsxmd/Vsxmd.md
+++ b/Vsxmd/Vsxmd.md
@@ -36,7 +36,7 @@
   - [ToAnchor(href)](#M-Vsxmd-Units-Extensions-ToAnchor-System-String- 'Vsxmd.Units.Extensions.ToAnchor(System.String)')
   - [ToHereLink(href)](#M-Vsxmd-Units-Extensions-ToHereLink-System-String- 'Vsxmd.Units.Extensions.ToHereLink(System.String)')
   - [ToLowerString(memberKind)](#M-Vsxmd-Units-Extensions-ToLowerString-Vsxmd-Units-MemberKind- 'Vsxmd.Units.Extensions.ToLowerString(Vsxmd.Units.MemberKind)')
-  - [ToMarkdownText(element,withLineBreak)](#M-Vsxmd-Units-Extensions-ToMarkdownText-System-Xml-Linq-XElement,System-Boolean- 'Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement,System.Boolean)')
+  - [ToMarkdownText(element)](#M-Vsxmd-Units-Extensions-ToMarkdownText-System-Xml-Linq-XElement- 'Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement)')
   - [ToReferenceLink(memberName,useShortName)](#M-Vsxmd-Units-Extensions-ToReferenceLink-System-String,System-Boolean- 'Vsxmd.Units.Extensions.ToReferenceLink(System.String,System.Boolean)')
 - [IConverter](#T-Vsxmd-IConverter 'Vsxmd.IConverter')
   - [ToMarkdown()](#M-Vsxmd-IConverter-ToMarkdown 'Vsxmd.IConverter.ToMarkdown')
@@ -621,8 +621,8 @@ The member kind's lowercase name.
 | ---- | ---- | ----------- |
 | memberKind | [Vsxmd.Units.MemberKind](#T-Vsxmd-Units-MemberKind 'Vsxmd.Units.MemberKind') | The member kind. |
 
-<a name='M-Vsxmd-Units-Extensions-ToMarkdownText-System-Xml-Linq-XElement,System-Boolean-'></a>
-### ToMarkdownText(element,withLineBreak) `method`
+<a name='M-Vsxmd-Units-Extensions-ToMarkdownText-System-Xml-Linq-XElement-'></a>
+### ToMarkdownText(element) `method`
 
 ##### Summary
 
@@ -638,14 +638,13 @@ The generated Markdwon content.
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | element | [System.Xml.Linq.XElement](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Xml.Linq.XElement 'System.Xml.Linq.XElement') | The XML element. |
-| withLineBreak | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | Optional parameter to transform two spaces into a linebreak. |
 
 ##### Example
 
 This method converts the following `summary`element.
 
 ```
-<summary>The <paramref name="element" /> value is <value>null</value>, it throws <c>ArgumentException</c>. For more, see <see cref="M:Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement,System.Boolean)" />.</summary>
+<summary>The <paramref name="element" /> value is <value>null</value>, it throws <c>ArgumentException</c>. For more, see <see cref="M:Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement)" />.</summary>
 ```
 
 To the below Markdown content.

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -353,18 +353,17 @@
             <param name="count">The number to except.</param>
             <returns>The generated enumerable.</returns>
         </member>
-        <member name="M:Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement,System.Boolean)">
+        <member name="M:Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement)">
             <summary>
             Convert the inline XML nodes to Markdown text.
             For example, it works for <c>summary</c> and <c>returns</c> elements.
             </summary>
             <param name="element">The XML element.</param>
-            <param name="withLineBreak">Optional parameter to transform two spaces into a linebreak.</param>
             <returns>The generated Markdwon content.</returns>
             <example>
             This method converts the following <c>summary</c> element.
             <code>
-            <summary>The <paramref name="element" /> value is <value>null</value>, it throws <c>ArgumentException</c>. For more, see <see cref="M:Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement,System.Boolean)"/>.</summary>
+            <summary>The <paramref name="element" /> value is <value>null</value>, it throws <c>ArgumentException</c>. For more, see <see cref="M:Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement)"/>.</summary>
             </code>
             To the below Markdown content.
             <code>

--- a/Vsxmd/Vsxmd.xml
+++ b/Vsxmd/Vsxmd.xml
@@ -40,7 +40,7 @@
             </summary>
             <remarks>
             Usage syntax:
-            <c>Vsxmd.exe &lt;input-XML-path&gt; [output-Markdown-path]</c>
+            <code>Vsxmd.exe &lt;input-XML-path&gt; [output-Markdown-path]</code>
             <para>The <c>input-XML-path</c> argument is required. It references to the VS generated XML documentation file.</para>
             <para>The <c>output-Markdown-path</c> argument is optional. It indicates the file path for the Markdown output file. When not specific, it will be a <c>.md</c> file with same file name as the XML documentation file, path at the XML documentation folder.</para>
             </remarks>
@@ -56,7 +56,7 @@
             <summary>
             Initializes a new instance of the <see cref="T:Vsxmd.Program.Test"/> class.
             <para>Test constructor without parameters.</para>
-            <para>See <see cref="M:Vsxmd.Program.Test.#ctor"/></para>
+            <para>See <see cref="M:Vsxmd.Program.Test.#ctor"/>.</para>
             </summary>
             <permission cref="T:Vsxmd.Program">Just for test.</permission>
         </member>
@@ -102,8 +102,8 @@
             <summary>
             Test backtick characters in summary comment.
             <para>See `should not inside code block`.</para>
-            <para>See <c>`backtick inside code block`</c></para>
-            <para>See `<c>code block inside backtick</c>`</para>
+            <para>See <c>`backtick inside code block`</c>.</para>
+            <para>See `<c>code block inside backtick</c>`.</para>
             </summary>
             <returns>Nothing.</returns>
         </member>
@@ -124,7 +124,7 @@
         <member name="M:Vsxmd.Program.TestGenericType`2.TestGenericMethod``2">
             <summary>
             Test generic method.
-            <para>See <see cref="M:Vsxmd.Program.TestGenericType`2.TestGenericMethod``2"/></para>
+            <para>See <see cref="M:Vsxmd.Program.TestGenericType`2.TestGenericMethod``2"/>.</para>
             </summary>
             <typeparam name="T3">Generic type 3.</typeparam>
             <typeparam name="T4">Generic type 4.</typeparam>
@@ -333,7 +333,7 @@
             </summary>
             <param name="code">The code span.</param>
             <returns>The Markdwon code span.</returns>
-            <remarks>Reference: http://meta.stackexchange.com/questions/55437/how-can-the-backtick-character-be-included-in-code </remarks>
+            <remarks>Reference: http://meta.stackexchange.com/questions/55437/how-can-the-backtick-character-be-included-in-code .</remarks>
         </member>
         <member name="M:Vsxmd.Units.Extensions.NthLast``1(System.Collections.Generic.IEnumerable{``0},System.Int32)">
             <summary>
@@ -359,10 +359,10 @@
             For example, it works for <c>summary</c> and <c>returns</c> elements.
             </summary>
             <param name="element">The XML element.</param>
-            <param name="withLineBreak">Optional parameter to transform two spaces into a linebreak</param>
+            <param name="withLineBreak">Optional parameter to transform two spaces into a linebreak.</param>
             <returns>The generated Markdwon content.</returns>
             <example>
-            This method converts the following <c>summary</c> element
+            This method converts the following <c>summary</c> element.
             <code>
             <summary>The <paramref name="element" /> value is <value>null</value>, it throws <c>ArgumentException</c>. For more, see <see cref="M:Vsxmd.Units.Extensions.ToMarkdownText(System.Xml.Linq.XElement,System.Boolean)"/>.</summary>
             </code>

--- a/Vsxmd/stylecop.json
+++ b/Vsxmd/stylecop.json
@@ -1,0 +1,8 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Junle Li"
+    }
+  }
+}


### PR DESCRIPTION
- Install `StyleCop.Analyzers` and `Microsoft.CodeAnalysis.FxCopAnalyzers`.
- Always pass the culture and ordinal string comparison to method parameters.
- Always add trailing comma for array and object.
- End the XML document with a period as a sentence.
- Removing unused method parameters and using statements.
- Suppress some warnings if they are targeting on unit test classes and methods.