### PR TITLE
Upgrade project to .Net Core 3 and ship as binaries.

### DIFF
--- a/Vsxmd/Units/Extensions.cs
+++ b/Vsxmd/Units/Extensions.cs
@@ -50,7 +50,7 @@ namespace Vsxmd.Units
         /// <param name="content">The content.</param>
         /// <returns>The escaped content.</returns>
         internal static string Escape(this string content) =>
-            content.Replace("`", @"\`");
+            content.Replace("`", @"\`", StringComparison.InvariantCulture);
 
         /// <summary>
         /// Generate an anchor for the <paramref name="href"/>.
@@ -91,7 +91,7 @@ namespace Vsxmd.Units
         internal static string AsCode(this string code)
         {
             string backticks = "`";
-            while (code.Contains(backticks))
+            while (code.Contains(backticks, StringComparison.InvariantCulture))
             {
                 backticks += "`";
             }
@@ -151,7 +151,7 @@ namespace Vsxmd.Units
             var text = node as XText;
             if (text != null)
             {
-                return text.Value.Escape().TrimStart(' ').Replace("            ", string.Empty);
+                return text.Value.Escape().TrimStart(' ').Replace("            ", string.Empty, StringComparison.InvariantCulture);
             }
 
             var child = node as XElement;
@@ -170,7 +170,7 @@ namespace Vsxmd.Units
                     case "code":
                         var lang = child.Attribute("lang")?.Value ?? string.Empty;
 
-                        string value = child.Nodes().First().ToString().Replace("\t", "    ");
+                        string value = child.Nodes().First().ToString().Replace("\t", "    ", StringComparison.InvariantCulture);
                         var indexOf = FindIndexOf(value);
 
                         var codeblockLines = value.Split(Environment.NewLine.ToCharArray())

--- a/Vsxmd/Units/MemberName.cs
+++ b/Vsxmd/Units/MemberName.cs
@@ -54,9 +54,9 @@ namespace Vsxmd.Units
             ? MemberKind.Constants
             : this.type == 'P'
             ? MemberKind.Property
-            : this.type == 'M' && this.name.Contains(".#ctor")
+            : this.type == 'M' && this.name.Contains(".#ctor", StringComparison.InvariantCulture)
             ? MemberKind.Constructor
-            : this.type == 'M' && !this.name.Contains(".#ctor")
+            : this.type == 'M' && !this.name.Contains(".#ctor", StringComparison.InvariantCulture)
             ? MemberKind.Method
             : MemberKind.NotSupported;
 

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
   <!-- NuGet Metadata: https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#nuget-metadata-properties -->
   <PropertyGroup>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Title>Vsxmd</Title>
     <Version>0.0.0</Version>
     <Authors>Junle Li, Sales Lessa Lopes</Authors>
@@ -28,25 +27,24 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/lijunle/Vsxmd</PackageProjectUrl>
     <PackageTags>Vsxmd VS XML document Markdown</PackageTags>
-    <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
-    <GenerateNuspecDependsOn>ExcludeDocumentationFile</GenerateNuspecDependsOn>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- The parameter _PackageFiles is declared in NuGet.Build.Tasks.Pack.targets -->
+    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\linux-x64\publish\" PackagePath="tools\linux-x64\" />
+    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\osx-x64\publish\" PackagePath="tools\osx-x64\" />
+    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\win-x64\publish\" PackagePath="tools\win-x64\" />
+    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\win-x86\publish\" PackagePath="tools\win-x86\" />
+  </ItemGroup>
   <ItemGroup>
     <Content Include="..\LICENSE" Link="LICENSE" PackagePath="\" />
     <Content Include="build\Vsxmd.targets" PackagePath="build\" />
     <Content Include="buildMultiTargeting\Vsxmd.targets" PackagePath="buildMultiTargeting\" />
   </ItemGroup>
-  <Target Name="ExcludeDocumentationFile">
-    <ItemGroup>
-      <!-- The _BuildOutputInPackage item group is declared in NuGet.Build.Tasks.Pack.targets -->
-      <_BuildOutputInPackage Remove="$(MSBuildProjectDirectory)\$(DocumentationFile)" />
-      <_BuildOutputInPackage Remove="$(MSBuildProjectDirectory)\**\$(DocumentationFile)" />
-    </ItemGroup>
-  </Target>
   <!-- Generate the Markdown file for itself -->
   <Target Name="VsxmdPreparation" AfterTargets="PostBuildEvent">
     <PropertyGroup>

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -23,7 +23,7 @@
     <Version>0.0.0</Version>
     <Authors>Junle Li, Sales Lessa Lopes</Authors>
     <Description>VS XML documentation -&gt; Markdown syntax.</Description>
-    <Copyright>Copyright 2018</Copyright>
+    <Copyright>Copyright 2015-Present</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/lijunle/Vsxmd</PackageProjectUrl>
     <PackageTags>Vsxmd VS XML document Markdown</PackageTags>

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -53,6 +53,6 @@
       <VsxmdBinaryDirectory>$(OutputPath)\..</VsxmdBinaryDirectory>
     </PropertyGroup>
   </Target>
-  <Import Project="$(MSBuildThisFileDirectory)\build\Vsxmd.targets" />
+  <!-- Import Project="$(MSBuildThisFileDirectory)\build\Vsxmd.targets" / -->
 
 </Project>

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -29,16 +29,14 @@
     <PackageTags>Vsxmd VS XML document Markdown</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <ItemGroup>
     <!-- The parameter _PackageFiles is declared in NuGet.Build.Tasks.Pack.targets -->
-    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\linux-x64\publish\" PackagePath="tools\linux-x64\" />
-    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\osx-x64\publish\" PackagePath="tools\osx-x64\" />
-    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\win-x64\publish\" PackagePath="tools\win-x64\" />
-    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\win-x86\publish\" PackagePath="tools\win-x86\" />
+    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\linux-x64\publish\Vsxmd" PackagePath="tools\linux-x64\" />
+    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\osx-x64\publish\Vsxmd" PackagePath="tools\osx-x64\" />
+    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\win-x64\publish\Vsxmd.exe" PackagePath="tools\win-x64\" />
+    <_PackageFiles Include="bin\$(Configuration)\$(TargetFramework)\win-x86\publish\Vsxmd.exe" PackagePath="tools\win-x86\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\LICENSE" Link="LICENSE" PackagePath="\" />

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -3,8 +3,7 @@
   <!-- Project Metadata -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition=" '$(MSBuildRuntimeType)' == 'Core' ">netcoreapp2.2</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(MSBuildRuntimeType)' != 'Core' ">netcoreapp2.2;net46</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DocumentationFile>Vsxmd.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <!-- NuGet Metadata: https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#nuget-metadata-properties -->
   <PropertyGroup>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Title>Vsxmd</Title>
     <Version>0.0.0</Version>
     <Authors>Junle Li, Sales Lessa Lopes</Authors>

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -45,9 +45,15 @@
   <!-- Generate the Markdown file for itself -->
   <Target Name="VsxmdPreparation" AfterTargets="PostBuildEvent">
     <PropertyGroup>
-      <VsxmdBinaryDirectory>$(OutputPath)\..</VsxmdBinaryDirectory>
+      <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">linux-x64</VsxmdRuntime>
+      <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">osx-x64</VsxmdRuntime>
+      <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">win-x64</VsxmdRuntime>
+      <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86' ">win-x86</VsxmdRuntime>
+      <VsxmdBinary Condition=" '$(RuntimeIdentifier)' == '' AND EXISTS('$(OutputPath)/Vsxmd.dll') ">$(OutputPath)/Vsxmd</VsxmdBinary>
+      <VsxmdBinary Condition=" '$(RuntimeIdentifier)' != '' AND EXISTS('$(OutputPath)/../Vsxmd.dll') ">$(OutputPath)/../Vsxmd</VsxmdBinary>
+      <VsxmdBinary Condition=" '$(RuntimeIdentifier)' != '' AND EXISTS('$(OutputPath)/../$(VsxmdRuntime)/Vsxmd.dll') ">$(OutputPath)/../$(VsxmdRuntime)/Vsxmd</VsxmdBinary>
     </PropertyGroup>
   </Target>
-  <!-- Import Project="$(MSBuildThisFileDirectory)\build\Vsxmd.targets" / -->
+  <Import Project="$(MSBuildThisFileDirectory)\build\Vsxmd.targets" />
 
 </Project>

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -41,7 +41,6 @@
   <ItemGroup>
     <Content Include="..\LICENSE" Link="LICENSE" PackagePath="\" />
     <Content Include="build\Vsxmd.targets" PackagePath="build\" />
-    <Content Include="buildMultiTargeting\Vsxmd.targets" PackagePath="buildMultiTargeting\" />
   </ItemGroup>
   <!-- Generate the Markdown file for itself -->
   <Target Name="VsxmdPreparation" AfterTargets="PostBuildEvent">

--- a/Vsxmd/build/Vsxmd.targets
+++ b/Vsxmd/build/Vsxmd.targets
@@ -7,7 +7,8 @@
       <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">win-x64</VsxmdRuntime>
       <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86' ">win-x86</VsxmdRuntime>
       <VsxmdBinaryDirectory>$(MSBuildThisFileDirectory)/../tools/$(VsxmdRuntime)</VsxmdBinaryDirectory>
-      <VsxmdBinary Condition=" '$(VsxmdBinary)' == '' AND EXISTS('$(VsxmdBinaryDirectory/Vsxmd.dll') ">$(VsxmdBinaryDirectory)/Vsxmd</VsxmdBinary>
+      <VsxmdBinary Condition=" '$(VsxmdBinary)' == '' AND EXISTS('$(VsxmdBinaryDirectory)/Vsxmd') ">$(VsxmdBinaryDirectory)/Vsxmd</VsxmdBinary>
+      <VsxmdBinary Condition=" '$(VsxmdBinary)' == '' AND EXISTS('$(VsxmdBinaryDirectory)/Vsxmd.exe') ">$(VsxmdBinaryDirectory)/Vsxmd.exe</VsxmdBinary>
       <VsxmdCommand Condition=" '$(VsxmdBinary)' == '' ">echo "The Vsxmd command is not currently available."</VsxmdCommand>
       <VsxmdCommand Condition=" '$(VsxmdBinary)' != '' ">"$(VsxmdBinary)" "$(DocumentationFile)" "$(DocumentationMarkdown)" "$(VsxmdAutoDeleteXml)"</VsxmdCommand>
     </PropertyGroup>

--- a/Vsxmd/build/Vsxmd.targets
+++ b/Vsxmd/build/Vsxmd.targets
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project TreatAsLocalProperty="VsxmdBinaryDirectory;VsxmdBinary;VsxmdCommand" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project TreatAsLocalProperty="VsxmdRuntime;VsxmdBinaryDirectory;VsxmdBinary;VsxmdCommand" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="Vsxmd" AfterTargets="PostBuildEvent">
     <PropertyGroup>
-      <VsxmdBinaryDirectory Condition=" '$(VsxmdBinaryDirectory)' == '' ">$(MSBuildThisFileDirectory)/../tools</VsxmdBinaryDirectory>
-      <VsxmdBinary Condition=" ('$(MSBuildRuntimeType)' == 'Full' OR '$(MSBuildRuntimeType)' == '') AND EXISTS('$(VsxmdBinaryDirectory)/net46') ">"$(VsxmdBinaryDirectory)/net46/Vsxmd.exe"</VsxmdBinary>
-      <VsxmdBinary Condition=" '$(MSBuildRuntimeType)' == 'Mono' AND EXISTS('$(VsxmdBinaryDirectory)/net46') ">mono "$(VsxmdBinaryDirectory)/net46/Vsxmd.exe"</VsxmdBinary>
-      <VsxmdBinary Condition=" '$(MSBuildRuntimeType)' == 'Core' AND EXISTS('$(VsxmdBinaryDirectory)/netcoreapp2.2') ">dotnet "$(VsxmdBinaryDirectory)/netcoreapp2.2/Vsxmd.dll"</VsxmdBinary>
+      <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">linux-x64</VsxmdRuntime>
+      <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">osx-x64</VsxmdRuntime>
+      <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">win-x64</VsxmdRuntime>
+      <VsxmdRuntime Condition=" $([MSBuild]::IsOsPlatform('Windows')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86' ">win-x86</VsxmdRuntime>
+      <VsxmdBinaryDirectory>$(MSBuildThisFileDirectory)/../tools/$(VsxmdRuntime)</VsxmdBinaryDirectory>
+      <VsxmdBinary Condition=" '$(VsxmdBinary)' == '' AND EXISTS('$(VsxmdBinaryDirectory/Vsxmd.dll') ">$(VsxmdBinaryDirectory)/Vsxmd</VsxmdBinary>
       <VsxmdCommand Condition=" '$(VsxmdBinary)' == '' ">echo "The Vsxmd command is not currently available."</VsxmdCommand>
-      <VsxmdCommand Condition=" '$(VsxmdBinary)' != '' ">$(VsxmdBinary) "$(DocumentationFile)" "$(DocumentationMarkdown)" "$(VsxmdAutoDeleteXml)"</VsxmdCommand>
+      <VsxmdCommand Condition=" '$(VsxmdBinary)' != '' ">"$(VsxmdBinary)" "$(DocumentationFile)" "$(DocumentationMarkdown)" "$(VsxmdAutoDeleteXml)"</VsxmdCommand>
     </PropertyGroup>
     <Message Text="Vsxmd starts to convert XML to Markdown." />
     <Exec Command="$(VsxmdCommand)" />

--- a/Vsxmd/buildMultiTargeting/Vsxmd.targets
+++ b/Vsxmd/buildMultiTargeting/Vsxmd.targets
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project>
-  <Import Project="..\build\Vsxmd.targets" />
-</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,10 +30,10 @@ before_build:
   - ps: ./Vsxmd/Test.ps1 -Prepare
 
 build_script:
-  - dotnet publish --runtime win-x64
-  - dotnet publish --runtime win-x86
-  - dotnet publish --runtime linux-x64
-  - dotnet publish --runtime osx-x64
+  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime linux-x64
+  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime osx-x64
+  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime win-x64
+  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime win-x86
   - 7z a -r Vsxmd\obj\Vsxmd.zip Vsxmd\bin\Release
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
 version: 0.0.{build}
 
 image:
-  - Visual Studio 2017
-  - Ubuntu
+  - Visual Studio 2019
 
 shallow_clone: true
 
@@ -28,8 +27,13 @@ dotnet_csproj:
   informational_version: "{version}"
 
 before_build:
-  - ps: msbuild -t:restore
   - ps: ./Vsxmd/Test.ps1 -Prepare
+
+build_script:
+  - dotnet publish --runtime win-x64
+  - dotnet publish --runtime win-x86
+  - dotnet publish --runtime linux-x64
+  - dotnet publish --runtime osx-x64
 
 test_script:
   - ps: ./Vsxmd/Test.ps1 -Run

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,9 +34,11 @@ build_script:
   - dotnet publish --runtime win-x86
   - dotnet publish --runtime linux-x64
   - dotnet publish --runtime osx-x64
+  - 7z a -r Vsxmd\obj\Vsxmd.zip Vsxmd\bin\Release
 
 test_script:
   - ps: ./Vsxmd/Test.ps1 -Run
 
 artifacts:
+  - path: 'Vsxmd\obj\Vsxmd.zip'
   - path: 'Vsxmd\**\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,10 +27,10 @@ before_build:
   - ps: Vsxmd\Test.ps1 -Prepare
 
 build_script:
-  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime linux-x64
-  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime osx-x64
-  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime win-x64
-  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime win-x86
+  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --verbosity normal --runtime linux-x64
+  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --verbosity normal --runtime osx-x64
+  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --verbosity normal --runtime win-x64
+  - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --verbosity normal --runtime win-x86
 
 test_script:
   - ps: Vsxmd\Test.ps1 -Run

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,10 +34,13 @@ build_script:
   - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime osx-x64
   - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime win-x64
   - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime win-x86
-  - 7z a -r Vsxmd\obj\Vsxmd.zip Vsxmd\bin\Release
 
 test_script:
   - ps: ./Vsxmd/Test.ps1 -Run
+
+after_test:
+  - 7z a -r Vsxmd\obj\Vsxmd.zip Vsxmd\bin\Release
+  - dotnet pack Vsxmd --no-restore --no-build
 
 artifacts:
   - path: 'Vsxmd\obj\Vsxmd.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,6 @@ platform:
 configuration:
   - Release
 
-matrix:
-  fast_finish: true
-
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
@@ -27,7 +24,7 @@ dotnet_csproj:
   informational_version: "{version}"
 
 before_build:
-  - ps: ./Vsxmd/Test.ps1 -Prepare
+  - ps: Vsxmd\Test.ps1 -Prepare
 
 build_script:
   - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime linux-x64
@@ -36,7 +33,7 @@ build_script:
   - dotnet publish /p:PublishSingleFile=true /p:PublishTrimmed=true --runtime win-x86
 
 test_script:
-  - ps: ./Vsxmd/Test.ps1 -Run
+  - ps: Vsxmd\Test.ps1 -Run
 
 after_test:
   - 7z a -r Vsxmd\obj\Vsxmd.zip Vsxmd\bin\Release


### PR DESCRIPTION
- Target the project to .Net Core 3.1
- Ship the NuGet package as OS-dependent binaries instead of DLL. It supports Windows/macOS/Linux.

Resolve #74 