### PR TITLE
Updated to support .net 6,7,8 and deprecate support for netcoreapp3.1

### DIFF
--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -1,17 +1,32 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Project Metadata -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <DocumentationFile>Vsxmd.xml</DocumentationFile>
   </PropertyGroup>
+		<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+				<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.*">
+						<PrivateAssets>all</PrivateAssets>
+						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+				</PackageReference>
+		</ItemGroup>
+		<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+				<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.*">
+						<PrivateAssets>all</PrivateAssets>
+						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+				</PackageReference>
+		</ItemGroup>
+		<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+				<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.*">
+						<PrivateAssets>all</PrivateAssets>
+						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+				</PackageReference>
+		</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
+ 
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 0.0.{build}
 
 image:
-  - Visual Studio 2019
+  - Visual Studio 2022
 
 shallow_clone: true
 


### PR DESCRIPTION
Current version is netcoreapp3.1 which has been deprecated.  Updated to support the latest frameworks.