### PR TITLE
Remove deprecated .NET versions and add .NET 9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, macos-latest]
         dotnet-version: [ '8.0', '9.0' ]
 
     steps:
@@ -23,10 +23,10 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
 
     - name: Restore dependencies
-      run: dotnet restore --framework net${{ matrix.dotnet-version }}
+      run: dotnet restore
 
     - name: Build
-      run: dotnet build --framework net${{ matrix.dotnet-version }} --no-restore
+      run: dotnet build --no-restore
 
     - name: Test
-      run: dotnet test --framework net${{ matrix.dotnet-version }} --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,10 +23,10 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
 
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore --framework net${{ matrix.dotnet-version.Split('.')[0] }}
 
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --framework net${{ matrix.dotnet-version.Split('.')[0] }} --no-restore
 
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --framework net${{ matrix.dotnet-version.Split('.')[0] }} --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,32 @@
+name: .NET
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        dotnet-version: [ '8.0.x', '9.0.x' ]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET SDK ${{ matrix.dotnet-version }}
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore
+
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        dotnet-version: [ '8.0.x', '9.0.x' ]
+        dotnet-version: [ '8.0', '9.0' ]
 
     steps:
     - uses: actions/checkout@v4
@@ -23,10 +23,10 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
 
     - name: Restore dependencies
-      run: dotnet restore --framework net${{ matrix.dotnet-version.Split('.')[0] }}
+      run: dotnet restore --framework net${{ matrix.dotnet-version }}
 
     - name: Build
-      run: dotnet build --framework net${{ matrix.dotnet-version.Split('.')[0] }} --no-restore
+      run: dotnet build --framework net${{ matrix.dotnet-version }} --no-restore
 
     - name: Test
-      run: dotnet test --framework net${{ matrix.dotnet-version.Split('.')[0] }} --no-build --verbosity normal
+      run: dotnet test --framework net${{ matrix.dotnet-version }} --no-build --verbosity normal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vsxmd
 
-[![AppVeyor](https://img.shields.io/appveyor/ci/lijunle/Vsxmd/master.svg?logo=AppVeyor&logoColor=white)](https://ci.appveyor.com/project/lijunle/vsxmd/branch/master)
+[![GitHub Workflow](https://github.com/lijunle/Vsxmd/actions/workflows/dotnet.yml/badge.svg)](https://github.com/lijunle/Vsxmd/actions/workflows/dotnet.yml)
 [![NuGet](https://img.shields.io/nuget/v/Vsxmd.svg?logo=NuGet&logoColor=white)](https://www.nuget.org/packages/Vsxmd)
 
 A MSBuild task to convert [XML documentation](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/xml-documentation-comments) to Markdown syntax. Support both .Net Framework and .Net Core projects.

--- a/Vsxmd.sln
+++ b/Vsxmd.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2018
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36301.6 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{570FDD3A-BD4C-428A-8B4A-19AE1091CF38}"
 	ProjectSection(SolutionItems) = preProject

--- a/Vsxmd/Vsxmd.csproj
+++ b/Vsxmd/Vsxmd.csproj
@@ -3,29 +3,14 @@
   <!-- Project Metadata -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <DocumentationFile>Vsxmd.xml</DocumentationFile>
   </PropertyGroup>
-		<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-				<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.*">
-						<PrivateAssets>all</PrivateAssets>
-						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-				</PackageReference>
-		</ItemGroup>
-		<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
-				<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.*">
-						<PrivateAssets>all</PrivateAssets>
-						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-				</PackageReference>
-		</ItemGroup>
-		<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
-				<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.*">
-						<PrivateAssets>all</PrivateAssets>
-						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-				</PackageReference>
-		</ItemGroup>
   <ItemGroup>
- 
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -45,6 +30,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <StartupObject>Vsxmd.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <!-- The parameter _PackageFiles is declared in NuGet.Build.Tasks.Pack.targets -->
@@ -72,5 +58,4 @@
     </PropertyGroup>
   </Target>
   <Import Project="$(MSBuildThisFileDirectory)\build\Vsxmd.targets" />
-
 </Project>


### PR DESCRIPTION
- Upgrade solution file to VS2022.
- Declare supporting .NET 8 and 9.
- Set up GitHub workflow and show its badge. 